### PR TITLE
Add a language switcher

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -127,7 +127,7 @@ class AppComponent extends React.Component {
   }
 
   render() {
-    const { t } = this.props;
+    const { t, i18n } = this.props;
     let sinsList = this.buildSinsList();
 
     let appClass = "App full-screen-app";
@@ -150,6 +150,19 @@ class AppComponent extends React.Component {
                   <Nav.Link href="/help">{t("navbar.help")}</Nav.Link>
                   <Nav.Link href="/about">{t("navbar.about")}</Nav.Link>
                 </Nav>
+                <select
+                  value={i18n.resolvedLanguage}
+                  onChange={(e) => {
+                    e.persist();
+                    i18n.changeLanguage(e.target.value);
+                  }}
+                  className="me-4"
+                >
+                  <option value="en">🇺🇸 English</option>
+                  <option value="de">🇩🇪 Deutsch</option>
+                  <option value="es">🇪🇸 Español</option>
+                  <option value="it">🇮🇹 Italiano</option>
+                </select>
                 <Nav.Link onClick={this.clearAll}>
                   <i className="fa fa-trash-o"></i> {t("navbar.clear")}
                 </Nav.Link>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -16,8 +16,12 @@ i18n
   // init i18next
   // for all options read: https://www.i18next.com/overview/configuration-options
   .init({
-    debug: true,
+    // debug: true,
     fallbackLng: "en",
+    supportedLngs: ["en", "de", "es", "it"],
+    // allow an empty value to count as invalid
+    // https://www.i18next.com/principles/fallback#missing-values-for-existing-keys
+    returnEmptyString: false,
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default
     },


### PR DESCRIPTION
Adds a language switcher to change the locale. We'll wait to merge this
'til we have at least 2 well-supported languages.

Note that language names are intentionally untranslated - they should
always be in the native locale.

Fixes #6.