### PR TITLE
Fix independent column scroll

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -158,7 +158,7 @@ class AppComponent extends React.Component {
           </Navbar>
           <Switch>
             <Route exact path="/">
-              <Container fluid={true}>
+              <Container fluid={true} className="column-container">
                 <Row className="h-100">
                   <Col xs="12" className="h-100">
                     <Swiper {...this.swiperParams}>

--- a/src/App.scss
+++ b/src/App.scss
@@ -31,6 +31,16 @@
   }
 }
 
+/* Make the container fill the window vertically, less the navbar.
+ * This is required to make each column scroll independently. */
+.navbar {
+  height: 4rem;
+  font-family: "Open Sans", sans-serif;
+}
+.column-container {
+  height: calc(100% - 4rem);
+}
+
 /* 100% height to fill vertically so we can scroll columns. */
 .swiper-container {
   height: 100%;


### PR DESCRIPTION
Our Bootstrap 5 upgrade in af939f973bee96c35f1b2b66219ca27b9efb46bc removed some scss that was required for our columns to scroll independently. Add this scss back in so that each column gets its own scrollbar.