### PR TITLE
Fix hamburger menu breakpoint

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -38,7 +38,7 @@ blockquote {
   margin-left: 4rem;
 }
 
-@include media-breakpoint-down(md) {
+@include media-breakpoint-down(lg) {
   .nav-link {
     background-color: $primary;
     border-top: 2px solid $white;


### PR DESCRIPTION
Our custom dropdown menu CSS was using the `md` breakpoint but the top nav switches to a hamburger menu at the large breakpoint.