### PR TITLE
Fix web manifest colors

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -19,6 +19,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#800080",
-  "background_color": "#cea990"
+  "theme_color": "#3c005a",
+  "background_color": "#f0dacc"
 }


### PR DESCRIPTION
When we updated our color scheme we missed the web manifest. This shows up e.g. in the title bar of a mobile web browser.