### PR TITLE
Feature/i18next scanner

### DIFF
--- a/i18next-scanner.config.js
+++ b/i18next-scanner.config.js
@@ -104,6 +104,7 @@ module.exports = {
           "kbd",
           "code",
           "footer",
+          "githubicon",
         ], // Which nodes are allowed to be kept in translations during defaultValue generation of <Trans>.
 
         // https://github.com/acornjs/acorn/tree/master/acorn#interface

--- a/i18next-scanner.config.js
+++ b/i18next-scanner.config.js
@@ -80,13 +80,13 @@ module.exports = {
 
     parser.parseFuncFromString(
       content,
-      { list: ["i18next._", "i18next.__"] },
+      { list: ["i18next._", "i18next.__", "t"] },
       (key, options) => {
         parser.set(
           key,
           Object.assign({}, options, {
             nsSeparator: false,
-            keySeparator: false,
+            keySeparator: ".",
           })
         );
         ++count;

--- a/i18next-scanner.config.js
+++ b/i18next-scanner.config.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const chalk = require("chalk");
+const Parser = require("i18next-scanner").Parser;
 
 module.exports = {
   input: [
@@ -14,41 +15,8 @@ module.exports = {
     removeUnusedKeys: false,
     sort: false,
     attr: false,
-    func: {
-      list: ["i18next.t", "i18n.t", "t"],
-      extensions: [".js", ".jsx"],
-    },
-    trans: {
-      component: "Trans",
-      i18nKey: "i18nKey",
-      defaultsKey: "defaults",
-      extensions: [".js", ".jsx"],
-      fallbackKey: false,
-
-      // https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0
-      supportBasicHtmlNodes: true, // Enables keeping the name of simple nodes (e.g. <br/>) in translations instead of indexed keys.
-      keepBasicHtmlNodesFor: [
-        "br",
-        "strong",
-        "i",
-        "p",
-        "vatican",
-        "github",
-        "mass",
-        "osc",
-        "website",
-        "app",
-        "a",
-        "kbd",
-        "code",
-      ], // Which nodes are allowed to be kept in translations during defaultValue generation of <Trans>.
-
-      // https://github.com/acornjs/acorn/tree/master/acorn#interface
-      acorn: {
-        ecmaVersion: 2020,
-        sourceType: "module", // defaults to 'module'
-      },
-    },
+    func: false,
+    trans: false,
     lngs: ["en", "es", "de", "it"],
     ns: ["translation"],
     defaultLng: "en",
@@ -75,30 +43,99 @@ module.exports = {
   transform: function customTransform(file, enc, done) {
     "use strict";
     const parser = this.parser;
+    const transParser = new Parser({
+      defaultValue: (lng, ns, key) => {
+        if (lng === "en") {
+          return key;
+        } else {
+          return "";
+        }
+      },
+      lngs: ["en", "es", "de", "it"],
+      resource: {
+        loadPath: "public/locales/{{lng}}/{{ns}}.json",
+        savePath: "public/locales/{{lng}}/{{ns}}.json",
+        jsonIndent: 2,
+        lineEnding: "\n",
+      },
+      keySeparator: ".",
+    });
     const content = fs.readFileSync(file.path, enc);
     let count = 0;
+    let transCount = 0;
 
     parser.parseFuncFromString(
       content,
-      { list: ["i18next._", "i18next.__", "t"] },
+      {
+        list: ["i18next.t", "i18n.t", "t"],
+        extensions: [".js", ".jsx"],
+      },
       (key, options) => {
-        parser.set(
-          key,
-          Object.assign({}, options, {
-            nsSeparator: false,
-            keySeparator: ".",
-          })
-        );
+        parser.set(key, options);
         ++count;
       }
     );
 
-    if (count > 0) {
+    let keysObj = {};
+
+    transParser.parseTransFromString(
+      content,
+      {
+        component: "Trans",
+        i18nKey: "i18nKey",
+        defaultsKey: "defaults",
+        extensions: [".js", ".jsx"],
+        fallbackKey: false,
+
+        // https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0
+        supportBasicHtmlNodes: true, // Enables keeping the name of simple nodes (e.g. <br/>) in translations instead of indexed keys.
+        keepBasicHtmlNodesFor: [
+          "br",
+          "strong",
+          "i",
+          "p",
+          "vatican",
+          "github",
+          "mass",
+          "osc",
+          "website",
+          "app",
+          "a",
+          "kbd",
+          "code",
+          "footer",
+        ], // Which nodes are allowed to be kept in translations during defaultValue generation of <Trans>.
+
+        // https://github.com/acornjs/acorn/tree/master/acorn#interface
+        acorn: {
+          ecmaVersion: 2020,
+          sourceType: "module", // defaults to 'module'
+        },
+      },
+      (key, options) => {
+        //if(false === key in keysObj) {
+        keysObj[key] = options;
+        parser.set(key, options);
+        ++transCount;
+        //}
+      }
+    );
+
+    if (count > 0 || transCount > 0) {
       console.log(
-        `i18next-scanner: count=${chalk.cyan(count)}, file=${chalk.yellow(
+        `i18next-scanner: t() count=${chalk.cyan(
+          count
+        )}, Trans count=${chalk.cyan(transCount)}, file=${chalk.yellow(
           JSON.stringify(file.relative)
         )}`
       );
+      if (transCount > 0) {
+        console.log(
+          `file=${chalk.yellow(JSON.stringify(file.relative))}, ${chalk.cyan(
+            JSON.stringify(keysObj)
+          )}`
+        );
+      }
     }
 
     done();

--- a/i18next-scanner.config.js
+++ b/i18next-scanner.config.js
@@ -1,0 +1,106 @@
+const fs = require("fs");
+const chalk = require("chalk");
+
+module.exports = {
+  input: [
+    "src/**/*.{js,jsx}",
+    // Use ! to filter out files or directories
+    "!src/**/*.test.{js,jsx}",
+    "!**/node_modules/**",
+  ],
+  output: "./",
+  options: {
+    debug: false,
+    removeUnusedKeys: false,
+    sort: false,
+    attr: false,
+    func: {
+      list: ["i18next.t", "i18n.t", "t"],
+      extensions: [".js", ".jsx"],
+    },
+    trans: {
+      component: "Trans",
+      i18nKey: "i18nKey",
+      defaultsKey: "defaults",
+      extensions: [".js", ".jsx"],
+      fallbackKey: false,
+
+      // https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0
+      supportBasicHtmlNodes: true, // Enables keeping the name of simple nodes (e.g. <br/>) in translations instead of indexed keys.
+      keepBasicHtmlNodesFor: [
+        "br",
+        "strong",
+        "i",
+        "p",
+        "vatican",
+        "github",
+        "mass",
+        "osc",
+        "website",
+        "app",
+        "a",
+        "kbd",
+        "code",
+      ], // Which nodes are allowed to be kept in translations during defaultValue generation of <Trans>.
+
+      // https://github.com/acornjs/acorn/tree/master/acorn#interface
+      acorn: {
+        ecmaVersion: 2020,
+        sourceType: "module", // defaults to 'module'
+      },
+    },
+    lngs: ["en", "es", "de", "it"],
+    ns: ["translation"],
+    defaultLng: "en",
+    defaultNs: "translation",
+    defaultValue: "",
+    resource: {
+      loadPath: "public/locales/{{lng}}/{{ns}}.json",
+      savePath: "public/locales/{{lng}}/{{ns}}.json",
+      jsonIndent: 2,
+      lineEnding: "\n",
+    },
+    nsSeparator: ":",
+    keySeparator: ".",
+    pluralSeparator: "_",
+    contextSeparator: "_",
+    contextDefaultValues: [],
+    interpolation: {
+      prefix: "{{",
+      suffix: "}}",
+    },
+    metadata: {},
+    allowDynamicKeys: false,
+  },
+  transform: function customTransform(file, enc, done) {
+    "use strict";
+    const parser = this.parser;
+    const content = fs.readFileSync(file.path, enc);
+    let count = 0;
+
+    parser.parseFuncFromString(
+      content,
+      { list: ["i18next._", "i18next.__"] },
+      (key, options) => {
+        parser.set(
+          key,
+          Object.assign({}, options, {
+            nsSeparator: false,
+            keySeparator: false,
+          })
+        );
+        ++count;
+      }
+    );
+
+    if (count > 0) {
+      console.log(
+        `i18next-scanner: count=${chalk.cyan(count)}, file=${chalk.yellow(
+          JSON.stringify(file.relative)
+        )}`
+      );
+    }
+
+    done();
+  },
+};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "i18next": "^21.5.2",
     "i18next-browser-languagedetector": "^6.1.2",
     "i18next-http-backend": "^1.3.1",
+    "i18next-scanner": "^4.2.0",
     "react": "^16.14.0",
     "react-bootstrap": "^2.5.0",
     "react-dom": "^16.14.0",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -1,427 +1,439 @@
 {
-    "navbar": {
-        "prayers": "Gebete",
-        "help": "Hilfe",
-        "about": "Über",
-        "clear": "Zurücksetzen"
+  "navbar": {
+    "prayers": "Gebete",
+    "help": "Hilfe",
+    "about": "Über",
+    "clear": "Zurücksetzen"
+  },
+  "examine_list": {
+    "examine": "Untersuchen"
+  },
+  "sins_list": {
+    "review": "Überprufen"
+  },
+  "walkthrough": {
+    "walkthrough": "Durchgang",
+    "in_the_name_of": "Im Namen des Vaters und des Sohnes und des Heiligen Geistes. Amen.",
+    "bless_me_father": "Segne mich Vater, denn ich habe gesündigt. Es ist ____ seit meiner letzten Beichte gewesen, und das sind meine Sünden:",
+    "these_are_my_sins": "Das sind meine Sünden, und ich bereue sie von ganzem Herzen.",
+    "your_confessor_may_offer": "(Ihr Beichtvater kann Ihnen einen Rat geben oder ein kurzes Gespräch mit Ihnen führen.)",
+    "your_confessor_will_assign": "(Dein Beichtvater wird Ihnen eine Buße auferlegen.) Beten Sie nun den Akt der Reue.",
+    "act_of_contrition": "<p>Mein Gott, ich bereue meine Sünden von ganzem Herzen.</p><p>Indem ich mich entschlossen habe, Unrecht zu tun und das Gute zu versäumen, habe ich gegen Dich gesündigt, den ich über alles lieben sollte.</p><p>Ich nehme mir fest vor, mit Deiner Hilfe Buße zu tun, nicht mehr zu sündigen und alles zu meiden, was mich zur Sünde verleitet.</p><p>Jesus Christus hat für uns gelitten und ist für uns gestorben. In seinem Namen, mein Gott, erbarme dich.</p>",
+    "god_the_father_of_mercies": "Gott, der Vater der Barmherzigkeit…",
+    "amen": "Amen.",
+    "the_lord_has_freed_you": "Der Herr hat Sie von der Sünde befreit. Gehen Sie in Frieden.",
+    "thanks_be_to_god": "Dank sei Gott dem Herrn."
+  },
+  "prayers": {
+    "prayers": "Gebete",
+    "prayer_before_confession": "Gebet vor der Beichte",
+    "act_of_contrition": "Akt der Reue",
+    "another_act_of_contrition": "Ein weiterer Akt der Reue",
+    "thanksgiving_after_confession": "Danksagung nach der Beichte",
+    "our_father": "Vater unser",
+    "hail_mary": "Ave Maria",
+    "hail_holy_queen": "Gegrüßt sei die Heilige Königin",
+    "prayer_before_confession_text": "<p>Mein Herr und Gott, ich habe gesündigt. Ich bin schuldig vor dir.<br />Gib mir die Kraft, deinem Minister zu sagen, was ich dir im Geheimen meines Herzens sage.<br />Vermehre meine Reue. Mache sie echter. Möge es wirklich ein Bedauern darüber sein, Dich und meinen Nächsten beleidigt zu haben, und nicht eine verletzte Selbstliebe.<br />Hilf mir, für meine Sünde zu büßen. Mögen die Leiden meines Lebens und meine kleinen Abtötungen mit den Leiden Jesu, Deines Sohnes, verbunden sein und dazu beitragen, die Sünde aus der Welt zu verbannen.<br />Amen.</p>",
+    "act_of_contrition_text": "<p>Mein Gott,<br />ich bereue meine Sünden von ganzem Herzen.<br />Indem ich mich entschlossen habe, Unrecht zu tun und Gutes zu unterlassen, habe ich gegen Dich gesündigt, den ich über alles lieben sollte.<br />Ich nehme mir fest vor, mit Deiner Hilfe Buße zu tun, nicht mehr zu sündigen und alles zu meiden, was mich zur Sünde verleitet.<br />Jesus Christus hat gelitten und ist für uns gestorben. In seinem Namen, mein Gott, sei mir gnädig.</p>",
+    "another_act_of_contrition_text": "<p>Oh mein Gott,<br />es tut mir von Herzen leid, dass ich Dich beleidigt habe, und ich verabscheue alle meine Sünden, weil ich den Verlust des Himmels und die Schmerzen der Hölle fürchte,<br />aber vor allem, weil sie Dich, meinen Gott, beleidigen, der so gut ist und meine Liebe verdient.<br />Ich nehme mir fest vor, mit Hilfe Deiner Gnade meine Sünden zu bekennen, Buße zu tun und mein Leben zu ändern.<br />Amen.</p>",
+    "thanksgiving_after_confession_text": "<p>Mein liebster Jesus,<br />ich habe alle meine Sünden so gut ich konnte erzählt. Ich habe mich bemüht, eine gute Beichte abzulegen. Ich bin sicher, dass Du mir verziehen hast. Ich danke Dir. Nur wegen all Deiner Leiden kann ich zur Beichte gehen und mich von meinen Sünden befreien. Dein Herz ist voll von Liebe und Barmherzigkeit für die armen Sünder. Ich liebe Dich, weil Du so gut zu mir bist.<br />Mein liebender Heiland,<br />ich werde versuchen, mich von der Sünde fernzuhalten und Dich jeden Tag mehr zu lieben.<br />Meine liebe Mutter Maria,<br />bitte für mich und hilf mir, meine Versprechen zu halten. Beschütze mich und lass mich nicht in die Sünde zurückfallen.</p>",
+    "our_father_text": "<p>Vater unser,<br />der Du bist im Himmel, geheiligt werde Dein Name,<br />dein Reich komme, Dein Wille geschehe, wie im Himmel so auf Erden.<br />Gib uns heute unser tägliches Brot, und vergib uns unsere Schuld,<br />wie auch wir vergeben unseren Schuldigern,<br />und führe uns nicht in Versuchung, sondern erlöse uns von dem Bösen.<br />Amen.</p>",
+    "hail_mary_text": "<p>Gegrüßt seist du Maria, voll der Gnade.<br />Der Herr ist mit dir.<br />Gesegnet bist du unter den Frauen, und gesegnet ist die Frucht deines Leibes, Jesus.<br />Heilige Maria, Mutter Gottes,<br />bete für uns Sünder, jetzt und in der Stunde unseres Todes.<br />Amen.</p>",
+    "hail_holy_queen_text": "<p>Gegrüßt seist du, heilige Königin, Mutter der Barmherzigkeit<br />Unser Leben, unsere Süße und unsere Hoffnung<br />Zu dir schreien wir, arme verbannte Kinder Evas. Zu dir senden wir unsere Seufzer, einsam und weinend in diesem Tal der Tränen.<br />Wende nun, gnädigste Fürsprecherin, deine Augen der Barmherzigkeit zu uns, und zeige uns nach diesem Exil die gesegnete Frucht deines Leibes, Jesus.<br />O milde, o liebende, o süße Jungfrau Maria. Bete für uns, heilige Mutter Gottes, dass wir der Verheißungen Christi würdig werden.<br />Amen.</p>"
+  },
+  "about": {
+    "about_confessit": "Über ConfessIt",
+    "about_confessit_text": "ConfessIt ist eine <vatican>römisch-katholische</vatican> Gewissenserforschung für Computer, Tablets und Telefone. Es ist einfach und leicht zu bedienen und kann dir helfen, dich an deine Sünden zu erinnern, wenn du zur Beichte gehst. Es gibt auch eine Anleitung zur Beichte, die Ihnen genau sagt, was der Priester sagen wird und wie Sie darauf reagieren sollten - ein großartiges Hilfsmittel, wenn Sie schon lange nicht mehr zur Beichte gegangen sind! Die Gewissenserforschung basiert auf den grundlegenden Lehren der katholischen Kirche, ist leicht zu verstehen und für moderne Katholiken relevant.",
+    "about_confession": "Über die Beichte",
+    "about_confession_intro": "Die Beichte ist das heilige Sakrament, durch das die Katholiken aus Gottes Barmherzigkeit Vergebung für ihre Sünden erlangen und so mit der Kirche, der Gemeinschaft der Gläubigen, dem Leib Christi, versöhnt werden.",
+    "ccc_quote": "<p>Es wird Sakrament der Bekehrung genannt, weil es den Aufruf Jesu zur Umkehr sakramental vergegenwärtigt, den ersten Schritt zur Rückkehr zum Vater (vgl. Mk 1,15; Lk 15,18), von dem man sich durch Sünde entfernt hat.</p><p>Es wird das Sakrament der Buße genannt, da es die persönlichen und kirchlichen Schritte des christlichen Sünders zur Umkehr, Buße und Genugtuung weiht.</p><p>Es wird das Sakrament der Beichte genannt, da die Offenbarung oder das Bekenntnis der Sünden gegenüber einem Priester ein wesentliches Element dieses Sakraments ist. In einem tiefen Sinn ist es auch ein \"Bekenntnis\" - Anerkennung und Lobpreisung - der Heiligkeit Gottes und seiner Barmherzigkeit gegenüber dem sündigen Menschen.</p><p>Es wird Sakrament der Vergebung genannt, denn durch die sakramentale Absolution des Priesters gewährt Gott dem Pönitenten \"Vergebung und Frieden\" (Ordo paenitantiae 46 Absolutionsformel).</p><p>Es wird Sakrament der Versöhnung genannt, denn es vermittelt dem Sünder die Liebe Gottes, der versöhnt: \"Seid versöhnt mit Gott\" (2 Kor 5,20). Wer aus der barmherzigen Liebe Gottes lebt, ist bereit, dem Ruf des Herrn zu folgen: \"Geh hin und versöhne dich mit deinem Bruder\" (Mt 5,24).</p><p>Die Bekehrung zu Christus, die neue Geburt in der Taufe, die Gabe des Heiligen Geistes und der als Speise empfangene Leib und das Blut Christi haben uns \"heilig und unbefleckt\" gemacht, so wie auch die Kirche selbst, die Braut Christi, \"heilig und unbefleckt\" ist (Eph 1,4; 5,27). Dennoch hat das in der christlichen Initiation empfangene neue Leben weder die Zerbrechlichkeit und Schwäche der menschlichen Natur noch die Neigung zur Sünde, die die Tradition als Konkupiszenz bezeichnet, beseitigt, die in den Getauften verbleibt, damit sie sich mit Hilfe der Gnade Christi im Kampf des christlichen Lebens bewähren können (vgl. Konzil von Trient, DS 1545; Lumen Gentium 40). Dies ist der Kampf der Bekehrung, der auf die Heiligkeit und das ewige Leben ausgerichtet ist, zu dem uns der Herr immer wieder aufruft.</p><p>Jesus ruft zur Bekehrung. Dieser Ruf ist ein wesentlicher Teil der Verkündigung des Reiches Gottes: \"Die Zeit ist erfüllt, und das Reich Gottes ist nahe herbeigekommen; tut Buße und glaubt an das Evangelium\" (Mk 1,15). Die Taufe ist der wichtigste Ort für die erste und grundlegende Bekehrung, aber auch danach ertönt der Ruf Christi zur Umkehr im Leben der Christen weiter. Diese zweite Bekehrung ist eine ununterbrochene Aufgabe für die ganze Kirche, die, \"die Sünder an ihren Schoß nehmend, zugleich heilig und immer läuterungsbedürftig ist (und) ständig den Weg der Buße und der Erneuerung geht\" (Lumen Gentium 8). Dieses Bemühen um Bekehrung ist nicht nur ein menschliches Werk. Es ist die Bewegung eines \"zerknirschten Herzens\", das von der Gnade gezogen und bewegt wird, um auf die barmherzige Liebe Gottes zu antworten, der uns zuerst geliebt hat (Ps 51,17; Joh 6,44; 12,32; 1 Joh 4,10). Der heilige Ambrosius sagt von den beiden Bekehrungen, dass es in der Kirche \"Wasser und Tränen gibt: das Wasser der Taufe und die Tränen der Reue\" (Epistel 41).</p><7>- Katechismus der Katholischen Kirche 1423-1424,1426; vgl. 1427-1429</7>",
+    "where_to_find": "Die Beichtzeiten werden in Ihrem örtlichen Pfarrblatt angegeben und sind auch online auf der Website Ihrer Pfarrei oder unter <mass>massimes.org</mass> zu finden. Sie können auch jederzeit einen Beichttermin vereinbaren, indem Sie sich an Ihre Gemeinde wenden.",
+    "about_confession_end": "Wenn Sie zur Beichte gehen, haben Sie in der Regel die Wahl, ob Sie anonym hinter einem Bildschirm knien oder von Angesicht zu Angesicht mit Ihrem Beichtvater sitzen. Was auch immer Sie beichten, Ihr Priester hat es schon einmal gehört. Denken Sie daran, dass er da ist, um Ihnen zu helfen.",
+    "about_this_app": "Über diese App",
+    "this_app_is_designed": "Diese App soll römischen Katholiken helfen, sich auf das Sakrament der Beichte vorzubereiten, indem sie ihr Gewissen prüfen. Sie ist <strong>NICHT</strong> ein Ersatz für die Beichte.",
+    "please_be_respectful": "Bitte nehmen Sie Rücksicht auf Ihre Mitmenschen, wenn Sie diese App nutzen. Ich empfehle Ihnen, Ihr Telefon auszuschalten, wenn Sie in Ihrer Kirche sind, und diese App zu benutzen, bevor Sie ankommen. Wenn Sie diese App in Ihrer Kirche oder während der Beichte verwenden, stellen Sie bitte sicher, dass Ihr Telefon auf lautlos gestellt ist.",
+    "this_website": "Diese Website, <website>ConfessIt.app</website>, basiert auf der <app>ConfessIt Android App</app> (2012 vom selben Entwickler erstellt). Es handelt sich zwar (noch) nicht um eine vollständige Reproduktion, aber sie soll die App einer größeren Anzahl von Nutzern auf einer breiteren Palette von Geräten zugänglich machen. (Diese Website funktioniert auf iOS, Android, Tablets und Computern!)",
+    "if_you_find": "Wenn du diese App nützlich findest, erwäge bitte, sie <strong>mit deinen Freunden und deiner Familie zu teilen</strong>. Erzählen Sie auf Facebook, Reddit, Twitter, in Ihrer Kirche oder in Ihrer Bibelstudiengruppe davon, um sie zu verbreiten!",
+    "privacy": "Datenschutz",
+    "information_you_enter": "Information you enter into this app is only stored on your device. It is not sent over the internet. We are able to do this using a technology provided by your web browser called <a>local storage</a>. We do not run Google Analytics or any other data collection mechanism on this site. Data you enter will be saved on your device until you hit <kbd>Clear</kbd> even if you close the window or refresh the page.",
+    "open_source": "Open Source",
+    "confessit_is_open_source": "ConfessIt ist Open Source. Wir entwickeln die App auf <i></i> <github>GitHub</github> und wir arbeiten in der <osc>Open Source Catholic</osc> Community auf Slack zusammen.",
+    "can_i_help_with_translations": "Kann ich bei Übersetzungen helfen?",
+    "confessit_is_translated": "ConfessIt is translated into multiple languages. If you'd like to help with this effort by adding a new translation or improving an existing translation, please read about how to do so on <github>GitHub</github> or get in touch with us on <osc>Open Source Catholic</osc> Slack.",
+    "can_i_help_write_code": "Kann ich beim Programmieren helfen?",
+    "we_welcome_new_contributions": "Wir begrüßen neue Beiträge. Wenn Sie zu ConfessIt beitragen möchten, lesen Sie am besten auf <1>GitHub</1> nach, wie Sie dies tun können.",
+    "about_the_developer": "",
+    "mike_kasberg": "<0>Mike Kasberg</0> develops ConfessIt in his free time, as a way of giving back to the church. He is also involved in a few other small projects to support Catholic organizations with technology.",
+    "information": ""
+  },
+  "help": {
+    "confessit_help": "",
+    "basic_usage": "",
+    "step_1": "In the <1>Examination</1> tab, mark <4>Yes</4> next to all the sins you want to remember to confess.",
+    "step_2": "Swipe to the next tab, <1>Sins</1>, to see a list of sins you've marked. You can review this list before or during confession if you wish.",
+    "step_3": "If you're unsure what to say in confession, swipe to the next tab, <1>Walkthrough</1>, to see roughly what you and the priest will say to each other in confession. You can review this during confession if you wish.",
+    "step_4": "After you've gone to confession, use the <2>Clear</2> button to clear all the sins you've marked.",
+    "data_persistence": "",
+    "data_persistence_text": "Data you enter is stored on your device (never sent over the Internet). Data you enter will be saved until you hit <2>Clear</2>, even if you close the window or refresh the page. Be sure to clear your data when you're done if you don't want other people who use this device to see your data!"
+  },
+  "welcome": {
+    "title": "",
+    "body": " ist ein Hilfsmittel, das römischen Katholiken helfen soll, vor der Beichte eine Gewissenserforschung durchzuführen. Wir hoffen, dass es Ihnen helfen wird, sich an die Sünden zu erinnern, die Sie seit Ihrer letzten Beichte begangen haben. Kreuzen Sie einfach das Kästchen <strong>Ja</strong> neben den Sünden in der Liste <strong>Untersuchung</strong> an oder tippen Sie auf die Plustaste, um Ihre eigenen hinzuzufügen. Scrolle dann nach rechts, um deine Sünden zu <strong>überprüfen</strong> und <strong>die Schritte der Beichte durchzugehen</strong>. <br /><br />Die von dir eingegebenen Daten werden auf deinem Gerät gespeichert (<strong>niemals</strong> über das Internet gesendet). Die von Ihnen eingegebenen Daten werden gespeichert, bis Sie auf <strong>Löschen</strong> klicken, auch wenn Sie das Fenster schließen oder die Seite aktualisieren. <br /><br />Gott segne Sie auf Ihrem Weg zur Heiligkeit!"
+  },
+  "commandments": {
+    "1": {
+      "title": "Erstes Gebot",
+      "text": "Ihr sollt keine anderen Götter haben vor mir. (2 Mose 20:3)",
+      "description": "Ich bin der Herr, dein Gott, der dich aus dem Land Ägypten, aus dem Haus der Knechtschaft, herausgeführt hat. Du sollst keine anderen Götter haben vor mir ... du sollst dich nicht vor ihnen niederwerfen und ihnen nicht dienen; denn ich, der Herr, dein Gott, bin ein eifersüchtiger Gott ... der Tausenden von Menschen, die mich lieben und meine Gebote halten, unerschütterliche Liebe entgegenbringt. (2. Mose 20,2-6) Die Hauptsünden Hochmut und Völlerei werden oft als Verstoß gegen dieses Gebot angesehen."
     },
-    "examine_list": {
-        "examine": "Untersuchen"
+    "2": {
+      "title": "Zweites Gebot",
+      "text": "Du sollst den Namen des Herrn, deines Gottes, nicht missbrauchen. (2. Mose 20:7)",
+      "description": "Du sollst den Namen des Herrn, deines Gottes, nicht missbrauchen; denn der Herr wird den nicht freisprechen, der seinen Namen missbraucht. (2. Mose 20:7)"
     },
-    "sins_list": {
-        "review": "Überprufen"
+    "3": {
+      "title": "Drittes Gebot",
+      "text": "Gedenke des Sabbattages, dass du ihn heilig hältst. (2. Mose 20:8)",
+      "description": "Gedenke des Sabbattages, dass du ihn heilig hältst. Sechs Tage sollst du arbeiten und alle deine Werke tun; aber der siebte Tag ist ein Sabbat des Herrn, deines Gottes; an ihm sollst du kein Werk tun... Denn in sechs Tagen hat der Herr Himmel und Erde gemacht und das Meer und alles, was darinnen ist, und ruhte am siebten Tag; darum segnete der Herr den Sabbattag und heiligte ihn. (2. Mose 20:8-11)"
     },
-    "walkthrough": {
-        "walkthrough": "Durchgang",
-        "in_the_name_of": "Im Namen des Vaters und des Sohnes und des Heiligen Geistes. Amen.",
-        "bless_me_father": "Segne mich Vater, denn ich habe gesündigt. Es ist ____ seit meiner letzten Beichte gewesen, und das sind meine Sünden:",
-        "these_are_my_sins": "Das sind meine Sünden, und ich bereue sie von ganzem Herzen.",
-        "your_confessor_may_offer": "(Ihr Beichtvater kann Ihnen einen Rat geben oder ein kurzes Gespräch mit Ihnen führen.)",
-        "your_confessor_will_assign": "(Dein Beichtvater wird Ihnen eine Buße auferlegen.) Beten Sie nun den Akt der Reue.",
-        "act_of_contrition": "<p>Mein Gott, ich bereue meine Sünden von ganzem Herzen.</p><p>Indem ich mich entschlossen habe, Unrecht zu tun und das Gute zu versäumen, habe ich gegen Dich gesündigt, den ich über alles lieben sollte.</p><p>Ich nehme mir fest vor, mit Deiner Hilfe Buße zu tun, nicht mehr zu sündigen und alles zu meiden, was mich zur Sünde verleitet.</p><p>Jesus Christus hat für uns gelitten und ist für uns gestorben. In seinem Namen, mein Gott, erbarme dich.</p>",
-        "god_the_father_of_mercies": "Gott, der Vater der Barmherzigkeit…",
-        "amen": "Amen.",
-        "the_lord_has_freed_you": "Der Herr hat Sie von der Sünde befreit. Gehen Sie in Frieden.",
-        "thanks_be_to_god": "Dank sei Gott dem Herrn."
+    "4": {
+      "title": "Viertes Gebot",
+      "text": "Ehre deinen Vater und deine Mutter. (2. Mose 20:12)",
+      "description": "Ehre deinen Vater und deine Mutter, damit du lange lebst in dem Land, das der Herr, dein Gott, dir gibt. (2. Mose 20:12)"
     },
-    "prayers": {
-        "prayers": "Gebete",
-        "prayer_before_confession": "Gebet vor der Beichte",
-        "act_of_contrition": "Akt der Reue",
-        "another_act_of_contrition": "Ein weiterer Akt der Reue",
-        "thanksgiving_after_confession": "Danksagung nach der Beichte",
-        "our_father": "Vater unser",
-        "hail_mary": "Ave Maria",
-        "hail_holy_queen": "Gegrüßt sei die Heilige Königin",
-        "prayer_before_confession_text": "<p>Mein Herr und Gott, ich habe gesündigt. Ich bin schuldig vor dir.<br />Gib mir die Kraft, deinem Minister zu sagen, was ich dir im Geheimen meines Herzens sage.<br />Vermehre meine Reue. Mache sie echter. Möge es wirklich ein Bedauern darüber sein, Dich und meinen Nächsten beleidigt zu haben, und nicht eine verletzte Selbstliebe.<br />Hilf mir, für meine Sünde zu büßen. Mögen die Leiden meines Lebens und meine kleinen Abtötungen mit den Leiden Jesu, Deines Sohnes, verbunden sein und dazu beitragen, die Sünde aus der Welt zu verbannen.<br />Amen.</p>",
-        "act_of_contrition_text": "<p>Mein Gott,<br />ich bereue meine Sünden von ganzem Herzen.<br />Indem ich mich entschlossen habe, Unrecht zu tun und Gutes zu unterlassen, habe ich gegen Dich gesündigt, den ich über alles lieben sollte.<br />Ich nehme mir fest vor, mit Deiner Hilfe Buße zu tun, nicht mehr zu sündigen und alles zu meiden, was mich zur Sünde verleitet.<br />Jesus Christus hat gelitten und ist für uns gestorben. In seinem Namen, mein Gott, sei mir gnädig.</p>",
-        "another_act_of_contrition_text": "<p>Oh mein Gott,<br />es tut mir von Herzen leid, dass ich Dich beleidigt habe, und ich verabscheue alle meine Sünden, weil ich den Verlust des Himmels und die Schmerzen der Hölle fürchte,<br />aber vor allem, weil sie Dich, meinen Gott, beleidigen, der so gut ist und meine Liebe verdient.<br />Ich nehme mir fest vor, mit Hilfe Deiner Gnade meine Sünden zu bekennen, Buße zu tun und mein Leben zu ändern.<br />Amen.</p>",
-        "thanksgiving_after_confession_text": "<p>Mein liebster Jesus,<br />ich habe alle meine Sünden so gut ich konnte erzählt. Ich habe mich bemüht, eine gute Beichte abzulegen. Ich bin sicher, dass Du mir verziehen hast. Ich danke Dir. Nur wegen all Deiner Leiden kann ich zur Beichte gehen und mich von meinen Sünden befreien. Dein Herz ist voll von Liebe und Barmherzigkeit für die armen Sünder. Ich liebe Dich, weil Du so gut zu mir bist.<br />Mein liebender Heiland,<br />ich werde versuchen, mich von der Sünde fernzuhalten und Dich jeden Tag mehr zu lieben.<br />Meine liebe Mutter Maria,<br />bitte für mich und hilf mir, meine Versprechen zu halten. Beschütze mich und lass mich nicht in die Sünde zurückfallen.</p>",
-        "our_father_text": "<p>Vater unser,<br />der Du bist im Himmel, geheiligt werde Dein Name,<br />dein Reich komme, Dein Wille geschehe, wie im Himmel so auf Erden.<br />Gib uns heute unser tägliches Brot, und vergib uns unsere Schuld,<br />wie auch wir vergeben unseren Schuldigern,<br />und führe uns nicht in Versuchung, sondern erlöse uns von dem Bösen.<br />Amen.</p>",
-        "hail_mary_text": "<p>Gegrüßt seist du Maria, voll der Gnade.<br />Der Herr ist mit dir.<br />Gesegnet bist du unter den Frauen, und gesegnet ist die Frucht deines Leibes, Jesus.<br />Heilige Maria, Mutter Gottes,<br />bete für uns Sünder, jetzt und in der Stunde unseres Todes.<br />Amen.</p>",
-        "hail_holy_queen_text": "<p>Gegrüßt seist du, heilige Königin, Mutter der Barmherzigkeit<br />Unser Leben, unsere Süße und unsere Hoffnung<br />Zu dir schreien wir, arme verbannte Kinder Evas. Zu dir senden wir unsere Seufzer, einsam und weinend in diesem Tal der Tränen.<br />Wende nun, gnädigste Fürsprecherin, deine Augen der Barmherzigkeit zu uns, und zeige uns nach diesem Exil die gesegnete Frucht deines Leibes, Jesus.<br />O milde, o liebende, o süße Jungfrau Maria. Bete für uns, heilige Mutter Gottes, dass wir der Verheißungen Christi würdig werden.<br />Amen.</p>"
+    "5": {
+      "title": "Fünftes Gebot",
+      "text": "Du sollst nicht töten. (2. Mose 20:13)",
+      "description": "Du sollst nicht töten. (2. Mose 20,13) Die Todsünde des Zorns wird oft mit diesem Gebot in Verbindung gebracht."
     },
-    "about": {
-        "about_confessit": "Über ConfessIt",
-        "about_confessit_text": "ConfessIt ist eine <vatican>römisch-katholische</vatican> Gewissenserforschung für Computer, Tablets und Telefone. Es ist einfach und leicht zu bedienen und kann dir helfen, dich an deine Sünden zu erinnern, wenn du zur Beichte gehst. Es gibt auch eine Anleitung zur Beichte, die Ihnen genau sagt, was der Priester sagen wird und wie Sie darauf reagieren sollten - ein großartiges Hilfsmittel, wenn Sie schon lange nicht mehr zur Beichte gegangen sind! Die Gewissenserforschung basiert auf den grundlegenden Lehren der katholischen Kirche, ist leicht zu verstehen und für moderne Katholiken relevant.",
-        "about_confession": "Über die Beichte",
-        "about_confession_intro": "Die Beichte ist das heilige Sakrament, durch das die Katholiken aus Gottes Barmherzigkeit Vergebung für ihre Sünden erlangen und so mit der Kirche, der Gemeinschaft der Gläubigen, dem Leib Christi, versöhnt werden.",
-        "ccc_quote": "<p>Es wird Sakrament der Bekehrung genannt, weil es den Aufruf Jesu zur Umkehr sakramental vergegenwärtigt, den ersten Schritt zur Rückkehr zum Vater (vgl. Mk 1,15; Lk 15,18), von dem man sich durch Sünde entfernt hat.</p><p>Es wird das Sakrament der Buße genannt, da es die persönlichen und kirchlichen Schritte des christlichen Sünders zur Umkehr, Buße und Genugtuung weiht.</p><p>Es wird das Sakrament der Beichte genannt, da die Offenbarung oder das Bekenntnis der Sünden gegenüber einem Priester ein wesentliches Element dieses Sakraments ist. In einem tiefen Sinn ist es auch ein \"Bekenntnis\" - Anerkennung und Lobpreisung - der Heiligkeit Gottes und seiner Barmherzigkeit gegenüber dem sündigen Menschen.</p><p>Es wird Sakrament der Vergebung genannt, denn durch die sakramentale Absolution des Priesters gewährt Gott dem Pönitenten \"Vergebung und Frieden\" (Ordo paenitantiae 46 Absolutionsformel).</p><p>Es wird Sakrament der Versöhnung genannt, denn es vermittelt dem Sünder die Liebe Gottes, der versöhnt: \"Seid versöhnt mit Gott\" (2 Kor 5,20). Wer aus der barmherzigen Liebe Gottes lebt, ist bereit, dem Ruf des Herrn zu folgen: \"Geh hin und versöhne dich mit deinem Bruder\" (Mt 5,24).</p><p>Die Bekehrung zu Christus, die neue Geburt in der Taufe, die Gabe des Heiligen Geistes und der als Speise empfangene Leib und das Blut Christi haben uns \"heilig und unbefleckt\" gemacht, so wie auch die Kirche selbst, die Braut Christi, \"heilig und unbefleckt\" ist (Eph 1,4; 5,27). Dennoch hat das in der christlichen Initiation empfangene neue Leben weder die Zerbrechlichkeit und Schwäche der menschlichen Natur noch die Neigung zur Sünde, die die Tradition als Konkupiszenz bezeichnet, beseitigt, die in den Getauften verbleibt, damit sie sich mit Hilfe der Gnade Christi im Kampf des christlichen Lebens bewähren können (vgl. Konzil von Trient, DS 1545; Lumen Gentium 40). Dies ist der Kampf der Bekehrung, der auf die Heiligkeit und das ewige Leben ausgerichtet ist, zu dem uns der Herr immer wieder aufruft.</p><p>Jesus ruft zur Bekehrung. Dieser Ruf ist ein wesentlicher Teil der Verkündigung des Reiches Gottes: \"Die Zeit ist erfüllt, und das Reich Gottes ist nahe herbeigekommen; tut Buße und glaubt an das Evangelium\" (Mk 1,15). Die Taufe ist der wichtigste Ort für die erste und grundlegende Bekehrung, aber auch danach ertönt der Ruf Christi zur Umkehr im Leben der Christen weiter. Diese zweite Bekehrung ist eine ununterbrochene Aufgabe für die ganze Kirche, die, \"die Sünder an ihren Schoß nehmend, zugleich heilig und immer läuterungsbedürftig ist (und) ständig den Weg der Buße und der Erneuerung geht\" (Lumen Gentium 8). Dieses Bemühen um Bekehrung ist nicht nur ein menschliches Werk. Es ist die Bewegung eines \"zerknirschten Herzens\", das von der Gnade gezogen und bewegt wird, um auf die barmherzige Liebe Gottes zu antworten, der uns zuerst geliebt hat (Ps 51,17; Joh 6,44; 12,32; 1 Joh 4,10). Der heilige Ambrosius sagt von den beiden Bekehrungen, dass es in der Kirche \"Wasser und Tränen gibt: das Wasser der Taufe und die Tränen der Reue\" (Epistel 41).</p><7>- Katechismus der Katholischen Kirche 1423-1424,1426; vgl. 1427-1429</7>",
-        "where_to_find": "Die Beichtzeiten werden in Ihrem örtlichen Pfarrblatt angegeben und sind auch online auf der Website Ihrer Pfarrei oder unter <mass>massimes.org</mass> zu finden. Sie können auch jederzeit einen Beichttermin vereinbaren, indem Sie sich an Ihre Gemeinde wenden.",
-        "about_confession_end": "Wenn Sie zur Beichte gehen, haben Sie in der Regel die Wahl, ob Sie anonym hinter einem Bildschirm knien oder von Angesicht zu Angesicht mit Ihrem Beichtvater sitzen. Was auch immer Sie beichten, Ihr Priester hat es schon einmal gehört. Denken Sie daran, dass er da ist, um Ihnen zu helfen.",
-        "about_this_app": "Über diese App",
-        "this_app_is_designed": "Diese App soll römischen Katholiken helfen, sich auf das Sakrament der Beichte vorzubereiten, indem sie ihr Gewissen prüfen. Sie ist <strong>NICHT</strong> ein Ersatz für die Beichte.",
-        "please_be_respectful": "Bitte nehmen Sie Rücksicht auf Ihre Mitmenschen, wenn Sie diese App nutzen. Ich empfehle Ihnen, Ihr Telefon auszuschalten, wenn Sie in Ihrer Kirche sind, und diese App zu benutzen, bevor Sie ankommen. Wenn Sie diese App in Ihrer Kirche oder während der Beichte verwenden, stellen Sie bitte sicher, dass Ihr Telefon auf lautlos gestellt ist.",
-        "this_website": "Diese Website, <website>ConfessIt.app</website>, basiert auf der <app>ConfessIt Android App</app> (2012 vom selben Entwickler erstellt). Es handelt sich zwar (noch) nicht um eine vollständige Reproduktion, aber sie soll die App einer größeren Anzahl von Nutzern auf einer breiteren Palette von Geräten zugänglich machen. (Diese Website funktioniert auf iOS, Android, Tablets und Computern!)",
-        "if_you_find": "Wenn du diese App nützlich findest, erwäge bitte, sie <strong>mit deinen Freunden und deiner Familie zu teilen</strong>. Erzählen Sie auf Facebook, Reddit, Twitter, in Ihrer Kirche oder in Ihrer Bibelstudiengruppe davon, um sie zu verbreiten!",
-        "privacy": "Datenschutz",
-        "information_you_enter": "Information you enter into this app is only stored on your device. It is not sent over the internet. We are able to do this using a technology provided by your web browser called <a>local storage</a>. We do not run Google Analytics or any other data collection mechanism on this site. Data you enter will be saved on your device until you hit <kbd>Clear</kbd> even if you close the window or refresh the page.",
-        "open_source": "Open Source",
-        "confessit_is_open_source": "ConfessIt ist Open Source. Wir entwickeln die App auf <i></i> <github>GitHub</github> und wir arbeiten in der <osc>Open Source Catholic</osc> Community auf Slack zusammen.",
-        "can_i_help_with_translations": "Kann ich bei Übersetzungen helfen?",
-        "confessit_is_translated": "ConfessIt is translated into multiple languages. If you'd like to help with this effort by adding a new translation or improving an existing translation, please read about how to do so on <github>GitHub</github> or get in touch with us on <osc>Open Source Catholic</osc> Slack.",
-        "can_i_help_write_code": "Kann ich beim Programmieren helfen?",
-        "we_welcome_new_contributions": "Wir begrüßen neue Beiträge. Wenn Sie zu ConfessIt beitragen möchten, lesen Sie am besten auf <1>GitHub</1> nach, wie Sie dies tun können.",
-        "about_the_developer": "",
-        "mike_kasberg": "",
-        "information": ""
+    "6": {
+      "title": "Sechstes Gebot",
+      "text": "Du sollst nicht ehebrechen. (2. Mose 20:14)",
+      "description": "Du sollst nicht ehebrechen. (2. Mose 20:14) Die Todsünde der Lust bricht dieses Gebot."
     },
-    "help": {
-        "confessit_help": "",
-        "basic_usage": "",
-        "step_1": "",
-        "step_2": "",
-        "step_3": "",
-        "step_4": "",
-        "data_persistence": "",
-        "data_persistence_text": ""
+    "7": {
+      "title": "Siebtes Gebot",
+      "text": "Du sollst nicht stehlen. (2. Mose 20:15)",
+      "description": "Du sollst nicht stehlen. (2. Mose 20:15) Die Todsünden Habgier und Trägheit werden oft als Verstoß gegen dieses Gebot angesehen."
     },
-    "welcome": {
-        "title": "",
-        "body": " ist ein Hilfsmittel, das römischen Katholiken helfen soll, vor der Beichte eine Gewissenserforschung durchzuführen. Wir hoffen, dass es Ihnen helfen wird, sich an die Sünden zu erinnern, die Sie seit Ihrer letzten Beichte begangen haben. Kreuzen Sie einfach das Kästchen <strong>Ja</strong> neben den Sünden in der Liste <strong>Untersuchung</strong> an oder tippen Sie auf die Plustaste, um Ihre eigenen hinzuzufügen. Scrolle dann nach rechts, um deine Sünden zu <strong>überprüfen</strong> und <strong>die Schritte der Beichte durchzugehen</strong>. <br /><br />Die von dir eingegebenen Daten werden auf deinem Gerät gespeichert (<strong>niemals</strong> über das Internet gesendet). Die von Ihnen eingegebenen Daten werden gespeichert, bis Sie auf <strong>Löschen</strong> klicken, auch wenn Sie das Fenster schließen oder die Seite aktualisieren. <br /><br />Gott segne Sie auf Ihrem Weg zur Heiligkeit!"
+    "8": {
+      "title": "Achtes Gebot",
+      "text": "Du sollst kein falsches Zeugnis gegen deinen Nächsten ablegen. (2. Mose 20:16)",
+      "description": "Du sollst kein falsches Zeugnis gegen deinen Nächsten ablegen. (2. Mose 20:16)"
     },
-    "commandments": {
-        "1": {
-            "title": "Erstes Gebot",
-            "text": "Ihr sollt keine anderen Götter haben vor mir. (2 Mose 20:3)",
-            "description": "Ich bin der Herr, dein Gott, der dich aus dem Land Ägypten, aus dem Haus der Knechtschaft, herausgeführt hat. Du sollst keine anderen Götter haben vor mir ... du sollst dich nicht vor ihnen niederwerfen und ihnen nicht dienen; denn ich, der Herr, dein Gott, bin ein eifersüchtiger Gott ... der Tausenden von Menschen, die mich lieben und meine Gebote halten, unerschütterliche Liebe entgegenbringt. (2. Mose 20,2-6) Die Hauptsünden Hochmut und Völlerei werden oft als Verstoß gegen dieses Gebot angesehen."
-        },
-        "2": {
-            "title": "Zweites Gebot",
-            "text": "Du sollst den Namen des Herrn, deines Gottes, nicht missbrauchen. (2. Mose 20:7)",
-            "description": "Du sollst den Namen des Herrn, deines Gottes, nicht missbrauchen; denn der Herr wird den nicht freisprechen, der seinen Namen missbraucht. (2. Mose 20:7)"
-        },
-        "3": {
-            "title": "Drittes Gebot",
-            "text": "Gedenke des Sabbattages, dass du ihn heilig hältst. (2. Mose 20:8)",
-            "description": "Gedenke des Sabbattages, dass du ihn heilig hältst. Sechs Tage sollst du arbeiten und alle deine Werke tun; aber der siebte Tag ist ein Sabbat des Herrn, deines Gottes; an ihm sollst du kein Werk tun... Denn in sechs Tagen hat der Herr Himmel und Erde gemacht und das Meer und alles, was darinnen ist, und ruhte am siebten Tag; darum segnete der Herr den Sabbattag und heiligte ihn. (2. Mose 20:8-11)"
-        },
-        "4": {
-            "title": "Viertes Gebot",
-            "text": "Ehre deinen Vater und deine Mutter. (2. Mose 20:12)",
-            "description": "Ehre deinen Vater und deine Mutter, damit du lange lebst in dem Land, das der Herr, dein Gott, dir gibt. (2. Mose 20:12)"
-        },
-        "5": {
-            "title": "Fünftes Gebot",
-            "text": "Du sollst nicht töten. (2. Mose 20:13)",
-            "description": "Du sollst nicht töten. (2. Mose 20,13) Die Todsünde des Zorns wird oft mit diesem Gebot in Verbindung gebracht."
-        },
-        "6": {
-            "title": "Sechstes Gebot",
-            "text": "Du sollst nicht ehebrechen. (2. Mose 20:14)",
-            "description": "Du sollst nicht ehebrechen. (2. Mose 20:14) Die Todsünde der Lust bricht dieses Gebot."
-        },
-        "7": {
-            "title": "Siebtes Gebot",
-            "text": "Du sollst nicht stehlen. (2. Mose 20:15)",
-            "description": "Du sollst nicht stehlen. (2. Mose 20:15) Die Todsünden Habgier und Trägheit werden oft als Verstoß gegen dieses Gebot angesehen."
-        },
-        "8": {
-            "title": "Achtes Gebot",
-            "text": "Du sollst kein falsches Zeugnis gegen deinen Nächsten ablegen. (2. Mose 20:16)",
-            "description": "Du sollst kein falsches Zeugnis gegen deinen Nächsten ablegen. (2. Mose 20:16)"
-        },
-        "9": {
-            "title": "Neuntes Gebot",
-            "text": "Du sollst nicht die Frau deines Nächsten begehren. (2. Mose 20:17)",
-            "description": "Du sollst nicht begehren deines Nächsten Weib (2. Mose 20,17) Die Todsünde der Eifersucht kann dieses Gebot brechen."
-        },
-        "10": {
-            "title": "Zehntes Gebot",
-            "text": "Du sollst nicht begehren deines Nächsten Gut. (2. Mose 20:17)",
-            "description": "Du sollst nicht begehren deines Nächsten Haus ... oder seinen Knecht oder seine Magd oder seinen Ochsen oder seinen Esel oder alles, was deines Nächsten ist. (2. Mose 20:17) Die Todsünde der Eifersucht kann dieses Gebot brechen."
-        },
-        "11": {
-            "title": "Gebote der Kirche",
-            "text": "Die Gebote der katholischen Kirche sind die Mindestanforderungen, die alle Katholiken erfüllen sollten.",
-            "description": "Die Gebote der Kirche stehen im Kontext eines sittlichen Lebens, das mit dem liturgischen Leben verbunden ist und von ihm genährt wird. Der obligatorische Charakter dieser von den Hirtenbehörden erlassenen positiven Gesetze soll den Gläubigen das notwendige Mindestmaß an Gebetsgeist und sittlicher Anstrengung, an Wachstum in der Gottes- und Nächstenliebe garantieren (KKK 2041)."
-        }
+    "9": {
+      "title": "Neuntes Gebot",
+      "text": "Du sollst nicht die Frau deines Nächsten begehren. (2. Mose 20:17)",
+      "description": "Du sollst nicht begehren deines Nächsten Weib (2. Mose 20,17) Die Todsünde der Eifersucht kann dieses Gebot brechen."
     },
-    "sins": {
-        "1": {
-            "text": "Habe ich mich geweigert, den Lehren der katholischen Kirche zu glauben?",
-            "text_past": "Ich weigerte mich, die Lehren der katholischen Kirche zu glauben.",
-            "detail": ""
-        },
-        "2": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "3": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "4": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "5": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "6": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "7": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "8": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "9": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "10": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "11": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "12": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "13": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "14": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "15": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "16": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "17": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "18": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "19": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "20": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "21": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "22": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "23": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "24": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "25": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "26": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "27": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "28": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "29": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "30": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "31": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "32": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "33": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "34": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "35": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "36": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "37": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "38": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "39": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "40": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "41": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "42": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "43": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "44": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "45": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "46": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "47": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "48": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "49": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "50": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "51": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "52": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "53": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "54": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "55": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "56": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "57": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        }
+    "10": {
+      "title": "Zehntes Gebot",
+      "text": "Du sollst nicht begehren deines Nächsten Gut. (2. Mose 20:17)",
+      "description": "Du sollst nicht begehren deines Nächsten Haus ... oder seinen Knecht oder seine Magd oder seinen Ochsen oder seinen Esel oder alles, was deines Nächsten ist. (2. Mose 20:17) Die Todsünde der Eifersucht kann dieses Gebot brechen."
+    },
+    "11": {
+      "title": "Gebote der Kirche",
+      "text": "Die Gebote der katholischen Kirche sind die Mindestanforderungen, die alle Katholiken erfüllen sollten.",
+      "description": "Die Gebote der Kirche stehen im Kontext eines sittlichen Lebens, das mit dem liturgischen Leben verbunden ist und von ihm genährt wird. Der obligatorische Charakter dieser von den Hirtenbehörden erlassenen positiven Gesetze soll den Gläubigen das notwendige Mindestmaß an Gebetsgeist und sittlicher Anstrengung, an Wachstum in der Gottes- und Nächstenliebe garantieren (KKK 2041)."
     }
+  },
+  "sins": {
+    "1": {
+      "text": "Habe ich mich geweigert, den Lehren der katholischen Kirche zu glauben?",
+      "text_past": "Ich weigerte mich, die Lehren der katholischen Kirche zu glauben.",
+      "detail": ""
+    },
+    "2": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "3": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "4": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "5": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "6": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "7": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "8": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "9": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "10": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "11": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "12": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "13": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "14": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "15": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "16": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "17": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "18": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "19": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "20": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "21": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "22": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "23": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "24": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "25": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "26": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "27": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "28": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "29": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "30": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "31": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "32": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "33": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "34": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "35": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "36": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "37": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "38": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "39": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "40": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "41": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "42": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "43": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "44": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "45": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "46": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "47": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "48": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "49": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "50": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "51": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "52": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "53": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "54": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "55": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "56": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "57": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    }
+  },
+  "addbutton": {
+    "add-custom-sin": "",
+    "i-sinned-by": "",
+    "cancel": "",
+    "add": ""
+  },
+  "examineitem": {
+    "yes": ""
+  },
+  "priestbubble": {
+    "priest": ""
+  }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -425,15 +425,15 @@
     }
   },
   "addbutton": {
-    "add-custom-sin": "",
-    "i-sinned-by": "",
-    "cancel": "",
-    "add": ""
+    "add-custom-sin": "Add custom sin",
+    "i-sinned-by": "I sinned by…",
+    "cancel": "Cancel",
+    "add": "Add"
   },
   "examineitem": {
-    "yes": ""
+    "yes": "Yes"
   },
   "priestbubble": {
-    "priest": ""
+    "priest": "Priest"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,427 +1,439 @@
 {
-    "navbar": {
-        "prayers": "Prayers",
-        "help": "Help",
-        "about": "About",
-        "clear": "Clear"
+  "navbar": {
+    "prayers": "Prayers",
+    "help": "Help",
+    "about": "About",
+    "clear": "Clear"
+  },
+  "examine_list": {
+    "examine": "Examine"
+  },
+  "sins_list": {
+    "review": "Review"
+  },
+  "walkthrough": {
+    "walkthrough": "Walkthrough",
+    "in_the_name_of": "In the name of the Father, and of the Son, and of the Holy Spirit. Amen.",
+    "bless_me_father": "Bless me father, for I have sinned. It has been ____ since my last confession, and these are my sins:",
+    "these_are_my_sins": "These are my sins, and I am sorry for them with all my heart.",
+    "your_confessor_may_offer": "(Your confessor may offer you some advice or have a short conversation with you.)",
+    "your_confessor_will_assign": "(Your confessor will assign you penance.) Now pray the act of contrition.",
+    "act_of_contrition": "<p>My God, I am sorry for my sins with all my heart.</p><p>In choosing to do wrong and failing to do good, I have sinned against You, whom I should love above all things.</p><p>I firmly intend with Your help to do penance, to sin no more, and to avoid whatever leads me to sin.</p><p>Jesus Christ suffered and died for us. In His name, my God, have mercy.</p>",
+    "god_the_father_of_mercies": "God, the Father of mercies…",
+    "amen": "Amen.",
+    "the_lord_has_freed_you": "The Lord has freed you from sin. Go in peace.",
+    "thanks_be_to_god": "Thanks be to God."
+  },
+  "prayers": {
+    "prayers": "Prayers",
+    "prayer_before_confession": "Prayer Before Confession",
+    "act_of_contrition": "Act Of Contrition",
+    "another_act_of_contrition": "Another Act Of Contrition",
+    "thanksgiving_after_confession": "Thanksgiving After Confession",
+    "our_father": "Our Father",
+    "hail_mary": "Hail Mary",
+    "hail_holy_queen": "Hail Holy Queen",
+    "prayer_before_confession_text": "<p>My Lord and God, I have sinned. I am guilty before you.<br />Grant me the strength to say to Your minister what I say to You in the secret of my heart.<br />Increase my repentance. Make it more genuine. May it really be a sorrow for having offended You and my neighbor rather than a wounded love of self.<br />Help me to atone for my sin. May the sufferings of my life and my little mortifications be joined with the sufferings of Jesus, Your Son, and cooperate in rooting sin from the world.<br />Amen.</p>",
+    "act_of_contrition_text": "<p>My God,<br />I am sorry for my sins with all my heart.<br />In choosing to do wrong and failing to do good, I have sinned against You, whom I should love above all things.<br />I firmly intend with Your help to do penance, to sin no more, and to avoid whatever leads me to sin.<br />Jesus Christ suffered and died for us. In His name, my God, have mercy.</p>",
+    "another_act_of_contrition_text": "<p>O my God,<br />I am heartily sorry for having offended Thee, and I detest all of my sins, because I dread the loss of heaven, and the pains of hell;<br />but most of all because they offend Thee, my God, Who are all good and deserving of my love.<br />I firmly resolve, with the help of Thy grace, to confess my sins, to do penance, and to amend my life.<br />Amen.</p>",
+    "thanksgiving_after_confession_text": "<p>My dearest Jesus,<br />I have told all my sins as well as I could. I have tried hard to make a good confession. I feel sure that You have forgiven me. I thank You. It is only because of all Your sufferings that I can go to confession and free myself from my sins. Your heart is full of love and mercy for poor sinners. I love You because You are so good to me.<br />My loving Savior,<br />I shall try to keep from sin and to love you more each day.<br />My dear Mother Mary,<br />pray for me and help me to keep my promises. Protect me and do not let me fall back into sin.</p>",
+    "our_father_text": "<p>Our Father,<br />Who art in heaven, hallowed be Thy name;<br />Thy kingdom come, Thy will be done, on earth as it is in heaven.<br />Give us this day our daily bread, and forgive us our trespasses,<br />as we forgive those who trespass against us;<br />and lead us not into temptation, but deliver us from evil.<br />Amen.</p>",
+    "hail_mary_text": "<p>Hail Mary, full of grace.<br />The Lord is with thee.<br />Blessed art thou among women, and blessed is the fruit of thy womb, Jesus.<br />Holy Mary, mother of God,<br />pray for us sinners, now and at the hour of our death.<br />Amen.</p>",
+    "hail_holy_queen_text": "<p>Hail, holy Queen, Mother of Mercy!<br />Our life, our sweetness, and our hope!<br />To thee do we cry, poor banished children of Eve. To thee do we send up our sighs, lonely and weeping in this valley of tears.<br />Turn then, most gracious advocate, thine eyes of mercy toward us; and after this our exile show unto us the blessed fruit of thy womb, Jesus.<br />O clement, O loving, O sweet virgin Mary. Pray for us, holy Mother of God, that we may be made worthy of the promises of Christ.<br />Amen.</p>"
+  },
+  "about": {
+    "about_confessit": "About ConfessIt",
+    "about_confessit_text": "ConfessIt is a <vatican>Roman Catholic</vatican> examination of conscience for computers, tablets, and phones. It's designed to be simple and easy to use, and it can help you remember your sins when you go to confession. There's also a confession walkthrough that tells you exactly what the priest will say and how you should respond - a great resource if you haven't been to confession in a while! The examination of conscience is based on fundamental Catholic church teachings, is easy to understand, and is relevant for modern Catholics.",
+    "about_confession": "About Confession",
+    "about_confession_intro": "Confession is the holy sacrament by which Catholics obtain pardon from God's mercy for their sins, and are thus reconciled with the Church, the community of believers, the Body of Christ.",
+    "ccc_quote": "<p>It is called the sacrament of conversion because it makes sacramentally present Jesus' call to conversion, the first step in returning to the Father (Cf. Mk 1:15; Lk 15:18) from whom one has strayed by sin.</p><p>It is called the sacrament of Penance, since it consecrates the Christian sinner's personal and ecclesial steps of conversion, penance, and satisfaction.</p><p>It is called the sacrament of confession, since the disclosure or confession of sins to a priest is an essential element of this sacrament. In a profound sense it is also a \"confession\" - acknowledgment and praise - of the holiness of God and of his mercy toward sinful man.</p><p>It is called the sacrament of forgiveness, since by the priest's sacramental absolution God grants the penitent \"pardon and peace\" (Ordo paenitantiae 46 formula of absolution).</p><p>It is called the sacrament of Reconciliation, because it imparts to the sinner the love of God who reconciles: \"Be reconciled to God\" (2 Cor 5:20). He who lives by God's merciful love is ready to respond to the Lord's call: \"Go; first be reconciled to your brother\" (Mt 5:24).</p><p>Conversion to Christ, the new birth of Baptism, the gift of the Holy Spirit and the Body and Blood of Christ received as food have made us \"holy and without blemish,\" just as the Church herself, the Bride of Christ, is \"holy and without blemish\" (Eph 1:4; 5:27). Nevertheless the new life received in Christian initiation has not abolished the frailty and weakness of human nature, nor the inclination to sin that tradition calls concupiscence, which remains in the baptized such that with the help of the grace of Christ they may prove themselves in the struggle of Christian life (Cf. Council of Trent, DS 1545; Lumen Gentium 40). This is the struggle of conversion directed toward holiness and eternal life to which the Lord never ceases to call us.</p><p>Jesus calls to conversion. This call is an essential part of the proclamation of the kingdom: \"The time is fulfilled, and the kingdom of God is at hand; repent, and believe in the gospel\" (Mk 1:15). Baptism is the principal place for the first and fundamental conversion, but then Christ's call to conversion continues to resound in the lives of Christians. This second conversion is an uninterrupted task for the whole Church who, \"clasping sinners to her bosom, (is) at once holy and always in need of purification, (and) follows constantly the path of penance and renewal\" (Lumen Gentium 8). This endeavor of conversion is not just a human work. It is the movement of a \"contrite heart,\" drawn and moved by grace to respond to the merciful love of God who loved us first (Ps 51:17; Jn 6:44; 12:32; 1 Jn 4:10). St. Ambrose says of the two conversions that, in the Church, \"there are water and tears: the water of Baptism and the tears of repentance\" (epistle 41).</p><7>— Catechism of the Catholic Church 1423-1424,1426; cf. 1427-1429</7>",
+    "where_to_find": "Confession times are listed in your local parish bulletin, and you can find them online at your parish website or at <mass>masstimes.org</mass>. You can also schedule a confession at any time you'd like by contacting your local parish.",
+    "about_confession_end": "When you go to confession, typically, you will have the choice of kneeling anonymously behind a screen or sitting face-to-face with your confessor.Don't be nervous about going to confession! Whatever you confess, your priest has heard it before. Remember, he is there to help you.",
+    "about_this_app": "About This App",
+    "this_app_is_designed": "This app is designed to help Roman Catholics prepare for the sacrament of confession by examining their conscience. It is <strong>NOT</strong> a substitute for confession.",
+    "please_be_respectful": "Please be respectful of those around you when you use this app. I recommend that you turn your phone off when you're inside your church, and use this app before you arrive. If you do use this app inside your church or during confession, please ensure your phone is in silent mode.",
+    "this_website": "This website, <website>ConfessIt.app</website>, is based on the <app>ConfessIt Android App</app> (created in 2012 by the same developer). While it's not (yet) a complete reproduction, it aims to make the app available to a wider range of users on a broader range of devices. (This site works on iOS, Android, tablets, and computers!)",
+    "if_you_find": "If you find this app useful, please consider <strong>sharing it</strong> with your friends and family. Tell people about it on Facebook, Reddit, Twitter, at your church, or in your Bible study group to help spread the word!",
+    "privacy": "Privacy",
+    "information_you_enter": "Information you enter into this app is only stored on your device. It is not sent over the internet. We are able to do this using a technology provided by your web browser called <a>local storage</a>. We do not run Google Analytics or any other data collection mechanism on this site. Data you enter will be saved on your device until you hit <kbd>Clear</kbd> even if you close the window or refresh the page.",
+    "open_source": "Open Source",
+    "confessit_is_open_source": "ConfessIt is open source. We develop the app on <i></i> <github>GitHub</github> and we collaborate in the <osc>Open Source Catholic</osc> community on Slack.",
+    "can_i_help_with_translations": "Can I help with translations?",
+    "confessit_is_translated": "ConfessIt is translated into multiple languages. If you'd like to help with this effort by adding a new translation or improving an existing translation, please read about how to do so on <github>GitHub</github> or get in touch with us on <osc>Open Source Catholic</osc> Slack.",
+    "can_i_help_write_code": "Can I help write code?",
+    "we_welcome_new_contributions": "We welcome new contributions. If you'd like to contribute to ConfessIt, the best way to begin is by reading about how to do so on <1>GitHub</1>.",
+    "about_the_developer": "About the Developer",
+    "mike_kasberg": "<0>Mike Kasberg</0> develops ConfessIt in his free time, as a way of giving back to the church. He is also involved in a few other small projects to support Catholic organizations with technology.",
+    "information": "Bible quotes in this app come from the Revised Standard Version of the Holy Bible, Second Catholic Edition. Information from the Catechism of the Catholic Church was also used."
+  },
+  "help": {
+    "confessit_help": "ConfessIt Help",
+    "basic_usage": "Basic Usage",
+    "step_1": "In the <strong>Examination</strong> tab, mark <strong>Yes</strong> next to all the sins you want to remember to confess.",
+    "step_2": "Swipe to the next tab, <strong>Sins</strong>, to see a list of sins you've marked. You can review this list before or during confession if you wish.",
+    "step_3": "If you're unsure what to say in confession, swipe to the next tab, <strong>Walkthrough</strong>, to see roughly what you and the priest will say to each other in confession. You can review this during confession if you wish.",
+    "step_4": "After you've gone to confession, use the <strong>Clear</strong> button to clear all the sins you've marked.",
+    "data_persistence": "Data Persistence",
+    "data_persistence_text": "Data you enter is stored on your device (never sent over the internet). Data you enter will be saved until you hit <strong>Clear</strong>, even if you close the window or refresh the page. Be sure to clear your data when you're done if you don't want other people who use this device to see your data!"
+  },
+  "welcome": {
+    "title": "Welcome!",
+    "body": " is a tool to help Roman Catholics walk through an examination of conscience prior to going to confession. We hope you'll find this useful to help remember sins you've committed since your last confession. Just check the <strong>Yes</strong> box next to sins in the <strong>Examine</strong> list, or tap the <kbd>+</kbd> button at the bottom right of the app to add your own. Then, scroll to the right to <strong>Review</strong> your sins and <strong>Walkthrough</strong> the steps of going to confession. <br /><br />Data you enter is stored on your device (<strong>never</strong> sent over the Internet). Data you enter will be saved until you hit <strong>Clear</strong> in the app settings, even if you close the window or refresh the page. <br /><br />God bless you on your path to holiness!"
+  },
+  "commandments": {
+    "1": {
+      "title": "First Commandment",
+      "text": "You shall have no other gods before Me. (Ex 20:3)",
+      "description": "I am the Lord your God, who brought you out of the land of Egypt, out of the house of bondage. You shall have no other gods before me… you shall not bow down to them or serve them; for I the Lord your God am a jealous God… showing steadfast love to thousands of those who love me and keep my commandments. (Ex 20:2-6) The capital sins of pride and gluttony are often considered to break this commandment."
     },
-    "examine_list": {
-        "examine": "Examine"
+    "2": {
+      "title": "Second Commandment",
+      "text": "You shall not take the name of the Lord your God in vain. (Ex 20:7)",
+      "description": "You shall not take the name of the Lord your God in vain; for the Lord will not hold him guiltless who takes his name in vain. (Ex 20:7)"
     },
-    "sins_list": {
-        "review": "Review"
+    "3": {
+      "title": "Third Commandment",
+      "text": "Remember the sabbath day, to keep it holy. (Ex 20:8)",
+      "description": "Remember the sabbath day, to keep it holy. Six days you shall labor, and do all your work; but the seventh day is a sabbath to the Lord your God; in it you shall not do any work… For in six days the Lord made heaven and earth, the sea, and all that is in them, and rested the seventh day; therefore the Lord blessed the sabbath day and hallowed it. (Ex 20:8-11)"
     },
-    "walkthrough": {
-        "walkthrough": "Walkthrough",
-        "in_the_name_of": "In the name of the Father, and of the Son, and of the Holy Spirit. Amen.",
-        "bless_me_father": "Bless me father, for I have sinned. It has been ____ since my last confession, and these are my sins:",
-        "these_are_my_sins": "These are my sins, and I am sorry for them with all my heart.",
-        "your_confessor_may_offer": "(Your confessor may offer you some advice or have a short conversation with you.)",
-        "your_confessor_will_assign": "(Your confessor will assign you penance.) Now pray the act of contrition.",
-        "act_of_contrition": "<p>My God, I am sorry for my sins with all my heart.</p><p>In choosing to do wrong and failing to do good, I have sinned against You, whom I should love above all things.</p><p>I firmly intend with Your help to do penance, to sin no more, and to avoid whatever leads me to sin.</p><p>Jesus Christ suffered and died for us. In His name, my God, have mercy.</p>",
-        "god_the_father_of_mercies": "God, the Father of mercies…",
-        "amen": "Amen.",
-        "the_lord_has_freed_you": "The Lord has freed you from sin. Go in peace.",
-        "thanks_be_to_god": "Thanks be to God."
+    "4": {
+      "title": "Fourth Commandment",
+      "text": "Honor your father and your mother. (Ex 20:12)",
+      "description": "Honor your father and mother, that your days may be long in the land which the Lord your God gives you. (Ex 20:12)"
     },
-    "prayers": {
-        "prayers": "Prayers",
-        "prayer_before_confession": "Prayer Before Confession",
-        "act_of_contrition": "Act Of Contrition",
-        "another_act_of_contrition": "Another Act Of Contrition",
-        "thanksgiving_after_confession": "Thanksgiving After Confession",
-        "our_father": "Our Father",
-        "hail_mary": "Hail Mary",
-        "hail_holy_queen": "Hail Holy Queen",
-        "prayer_before_confession_text": "<p>My Lord and God, I have sinned. I am guilty before you.<br />Grant me the strength to say to Your minister what I say to You in the secret of my heart.<br />Increase my repentance. Make it more genuine. May it really be a sorrow for having offended You and my neighbor rather than a wounded love of self.<br />Help me to atone for my sin. May the sufferings of my life and my little mortifications be joined with the sufferings of Jesus, Your Son, and cooperate in rooting sin from the world.<br />Amen.</p>",
-        "act_of_contrition_text": "<p>My God,<br />I am sorry for my sins with all my heart.<br />In choosing to do wrong and failing to do good, I have sinned against You, whom I should love above all things.<br />I firmly intend with Your help to do penance, to sin no more, and to avoid whatever leads me to sin.<br />Jesus Christ suffered and died for us. In His name, my God, have mercy.</p>",
-        "another_act_of_contrition_text": "<p>O my God,<br />I am heartily sorry for having offended Thee, and I detest all of my sins, because I dread the loss of heaven, and the pains of hell;<br />but most of all because they offend Thee, my God, Who are all good and deserving of my love.<br />I firmly resolve, with the help of Thy grace, to confess my sins, to do penance, and to amend my life.<br />Amen.</p>",
-        "thanksgiving_after_confession_text": "<p>My dearest Jesus,<br />I have told all my sins as well as I could. I have tried hard to make a good confession. I feel sure that You have forgiven me. I thank You. It is only because of all Your sufferings that I can go to confession and free myself from my sins. Your heart is full of love and mercy for poor sinners. I love You because You are so good to me.<br />My loving Savior,<br />I shall try to keep from sin and to love you more each day.<br />My dear Mother Mary,<br />pray for me and help me to keep my promises. Protect me and do not let me fall back into sin.</p>",
-        "our_father_text": "<p>Our Father,<br />Who art in heaven, hallowed be Thy name;<br />Thy kingdom come, Thy will be done, on earth as it is in heaven.<br />Give us this day our daily bread, and forgive us our trespasses,<br />as we forgive those who trespass against us;<br />and lead us not into temptation, but deliver us from evil.<br />Amen.</p>",
-        "hail_mary_text": "<p>Hail Mary, full of grace.<br />The Lord is with thee.<br />Blessed art thou among women, and blessed is the fruit of thy womb, Jesus.<br />Holy Mary, mother of God,<br />pray for us sinners, now and at the hour of our death.<br />Amen.</p>",
-        "hail_holy_queen_text": "<p>Hail, holy Queen, Mother of Mercy!<br />Our life, our sweetness, and our hope!<br />To thee do we cry, poor banished children of Eve. To thee do we send up our sighs, lonely and weeping in this valley of tears.<br />Turn then, most gracious advocate, thine eyes of mercy toward us; and after this our exile show unto us the blessed fruit of thy womb, Jesus.<br />O clement, O loving, O sweet virgin Mary. Pray for us, holy Mother of God, that we may be made worthy of the promises of Christ.<br />Amen.</p>"
+    "5": {
+      "title": "Fifth Commandment",
+      "text": "You shall not kill. (Ex 20:13)",
+      "description": "You shall not kill. (Ex 20:13) The capital sin of anger is often associated with this commandment."
     },
-    "about": {
-        "about_confessit": "About ConfessIt",
-        "about_confessit_text": "ConfessIt is a <vatican>Roman Catholic</vatican> examination of conscience for computers, tablets, and phones. It's designed to be simple and easy to use, and it can help you remember your sins when you go to confession. There's also a confession walkthrough that tells you exactly what the priest will say and how you should respond - a great resource if you haven't been to confession in a while! The examination of conscience is based on fundamental Catholic church teachings, is easy to understand, and is relevant for modern Catholics.",
-        "about_confession": "About Confession",
-        "about_confession_intro": "Confession is the holy sacrament by which Catholics obtain pardon from God's mercy for their sins, and are thus reconciled with the Church, the community of believers, the Body of Christ.",
-        "ccc_quote": "<p>It is called the sacrament of conversion because it makes sacramentally present Jesus' call to conversion, the first step in returning to the Father (Cf. Mk 1:15; Lk 15:18) from whom one has strayed by sin.</p><p>It is called the sacrament of Penance, since it consecrates the Christian sinner's personal and ecclesial steps of conversion, penance, and satisfaction.</p><p>It is called the sacrament of confession, since the disclosure or confession of sins to a priest is an essential element of this sacrament. In a profound sense it is also a \"confession\" - acknowledgment and praise - of the holiness of God and of his mercy toward sinful man.</p><p>It is called the sacrament of forgiveness, since by the priest's sacramental absolution God grants the penitent \"pardon and peace\" (Ordo paenitantiae 46 formula of absolution).</p><p>It is called the sacrament of Reconciliation, because it imparts to the sinner the love of God who reconciles: \"Be reconciled to God\" (2 Cor 5:20). He who lives by God's merciful love is ready to respond to the Lord's call: \"Go; first be reconciled to your brother\" (Mt 5:24).</p><p>Conversion to Christ, the new birth of Baptism, the gift of the Holy Spirit and the Body and Blood of Christ received as food have made us \"holy and without blemish,\" just as the Church herself, the Bride of Christ, is \"holy and without blemish\" (Eph 1:4; 5:27). Nevertheless the new life received in Christian initiation has not abolished the frailty and weakness of human nature, nor the inclination to sin that tradition calls concupiscence, which remains in the baptized such that with the help of the grace of Christ they may prove themselves in the struggle of Christian life (Cf. Council of Trent, DS 1545; Lumen Gentium 40). This is the struggle of conversion directed toward holiness and eternal life to which the Lord never ceases to call us.</p><p>Jesus calls to conversion. This call is an essential part of the proclamation of the kingdom: \"The time is fulfilled, and the kingdom of God is at hand; repent, and believe in the gospel\" (Mk 1:15). Baptism is the principal place for the first and fundamental conversion, but then Christ's call to conversion continues to resound in the lives of Christians. This second conversion is an uninterrupted task for the whole Church who, \"clasping sinners to her bosom, (is) at once holy and always in need of purification, (and) follows constantly the path of penance and renewal\" (Lumen Gentium 8). This endeavor of conversion is not just a human work. It is the movement of a \"contrite heart,\" drawn and moved by grace to respond to the merciful love of God who loved us first (Ps 51:17; Jn 6:44; 12:32; 1 Jn 4:10). St. Ambrose says of the two conversions that, in the Church, \"there are water and tears: the water of Baptism and the tears of repentance\" (epistle 41).</p><7>— Catechism of the Catholic Church 1423-1424,1426; cf. 1427-1429</7>",
-        "where_to_find": "Confession times are listed in your local parish bulletin, and you can find them online at your parish website or at <mass>masstimes.org</mass>. You can also schedule a confession at any time you'd like by contacting your local parish.",
-        "about_confession_end": "When you go to confession, typically, you will have the choice of kneeling anonymously behind a screen or sitting face-to-face with your confessor.Don't be nervous about going to confession! Whatever you confess, your priest has heard it before. Remember, he is there to help you.",
-        "about_this_app": "About This App",
-        "this_app_is_designed": "This app is designed to help Roman Catholics prepare for the sacrament of confession by examining their conscience. It is <strong>NOT</strong> a substitute for confession.",
-        "please_be_respectful": "Please be respectful of those around you when you use this app. I recommend that you turn your phone off when you're inside your church, and use this app before you arrive. If you do use this app inside your church or during confession, please ensure your phone is in silent mode.",
-        "this_website": "This website, <website>ConfessIt.app</website>, is based on the <app>ConfessIt Android App</app> (created in 2012 by the same developer). While it's not (yet) a complete reproduction, it aims to make the app available to a wider range of users on a broader range of devices. (This site works on iOS, Android, tablets, and computers!)",
-        "if_you_find": "If you find this app useful, please consider <strong>sharing it</strong> with your friends and family. Tell people about it on Facebook, Reddit, Twitter, at your church, or in your Bible study group to help spread the word!",
-        "privacy": "Privacy",
-        "information_you_enter": "Information you enter into this app is only stored on your device. It is not sent over the internet. We are able to do this using a technology provided by your web browser called <a>local storage</a>. We do not run Google Analytics or any other data collection mechanism on this site. Data you enter will be saved on your device until you hit <kbd>Clear</kbd> even if you close the window or refresh the page.",
-        "open_source": "Open Source",
-        "confessit_is_open_source": "ConfessIt is open source. We develop the app on <i></i> <github>GitHub</github> and we collaborate in the <osc>Open Source Catholic</osc> community on Slack.",
-        "can_i_help_with_translations": "Can I help with translations?",
-        "confessit_is_translated": "ConfessIt is translated into multiple languages. If you'd like to help with this effort by adding a new translation or improving an existing translation, please read about how to do so on <github>GitHub</github> or get in touch with us on <osc>Open Source Catholic</osc> Slack.",
-        "can_i_help_write_code": "Can I help write code?",
-        "we_welcome_new_contributions": "We welcome new contributions. If you'd like to contribute to ConfessIt, the best way to begin is by reading about how to do so on <1>GitHub</1>.",
-        "about_the_developer": "About the Developer",
-        "mike_kasberg": "<0>Mike Kasberg</0> develops ConfessIt in his free time, as a way of giving back to the church. He is also involved in a few other small projects to support Catholic organizations with technology.",
-        "information": "Bible quotes in this app come from the Revised Standard Version of the Holy Bible, Second Catholic Edition. Information from the Catechism of the Catholic Church was also used."
+    "6": {
+      "title": "Sixth Commandment",
+      "text": "You shall not commit adultery. (Ex 20:14)",
+      "description": "You shall not commit adultery. (Ex 20:14) The capital sin of lust breaks this commandment."
     },
-    "help": {
-        "confessit_help": "ConfessIt Help",
-        "basic_usage": "Basic Usage",
-        "step_1": "In the <strong>Examination</strong> tab, mark <strong>Yes</strong> next to all the sins you want to remember to confess.",
-        "step_2": "Swipe to the next tab, <strong>Sins</strong>, to see a list of sins you've marked. You can review this list before or during confession if you wish.",
-        "step_3": "If you're unsure what to say in confession, swipe to the next tab, <strong>Walkthrough</strong>, to see roughly what you and the priest will say to each other in confession. You can review this during confession if you wish.",
-        "step_4": "After you've gone to confession, use the <strong>Clear</strong> button to clear all the sins you've marked.",
-        "data_persistence": "Data Persistence",
-        "data_persistence_text": "Data you enter is stored on your device (never sent over the internet). Data you enter will be saved until you hit <strong>Clear</strong>, even if you close the window or refresh the page. Be sure to clear your data when you're done if you don't want other people who use this device to see your data!"
+    "7": {
+      "title": "Seventh Commandment",
+      "text": "You shall not steal. (Ex 20:15)",
+      "description": "You shall not steal. (Ex 20:15) The capital sins of greed and sloth are often considered to break this commandment."
     },
-    "welcome": {
-        "title": "Welcome!",
-        "body": " is a tool to help Roman Catholics walk through an examination of conscience prior to going to confession. We hope you'll find this useful to help remember sins you've committed since your last confession. Just check the <strong>Yes</strong> box next to sins in the <strong>Examine</strong> list, or tap the <kbd>+</kbd> button at the bottom right of the app to add your own. Then, scroll to the right to <strong>Review</strong> your sins and <strong>Walkthrough</strong> the steps of going to confession. <br /><br />Data you enter is stored on your device (<strong>never</strong> sent over the Internet). Data you enter will be saved until you hit <strong>Clear</strong> in the app settings, even if you close the window or refresh the page. <br /><br />God bless you on your path to holiness!"
+    "8": {
+      "title": "Eighth Commandment",
+      "text": "You shall not bear false witness against your neighbor. (Ex 20:16)",
+      "description": "You shall not bear false witness against your neighbor. (Ex 20:16)"
     },
-    "commandments": {
-        "1": {
-            "title": "First Commandment",
-            "text": "You shall have no other gods before Me. (Ex 20:3)",
-            "description": "I am the Lord your God, who brought you out of the land of Egypt, out of the house of bondage. You shall have no other gods before me… you shall not bow down to them or serve them; for I the Lord your God am a jealous God… showing steadfast love to thousands of those who love me and keep my commandments. (Ex 20:2-6) The capital sins of pride and gluttony are often considered to break this commandment."
-        },
-        "2": {
-            "title": "Second Commandment",
-            "text": "You shall not take the name of the Lord your God in vain. (Ex 20:7)",
-            "description": "You shall not take the name of the Lord your God in vain; for the Lord will not hold him guiltless who takes his name in vain. (Ex 20:7)"
-        },
-        "3": {
-            "title": "Third Commandment",
-            "text": "Remember the sabbath day, to keep it holy. (Ex 20:8)",
-            "description": "Remember the sabbath day, to keep it holy. Six days you shall labor, and do all your work; but the seventh day is a sabbath to the Lord your God; in it you shall not do any work… For in six days the Lord made heaven and earth, the sea, and all that is in them, and rested the seventh day; therefore the Lord blessed the sabbath day and hallowed it. (Ex 20:8-11)"
-        },
-        "4": {
-            "title": "Fourth Commandment",
-            "text": "Honor your father and your mother. (Ex 20:12)",
-            "description": "Honor your father and mother, that your days may be long in the land which the Lord your God gives you. (Ex 20:12)"
-        },
-        "5": {
-            "title": "Fifth Commandment",
-            "text": "You shall not kill. (Ex 20:13)",
-            "description": "You shall not kill. (Ex 20:13) The capital sin of anger is often associated with this commandment."
-        },
-        "6": {
-            "title": "Sixth Commandment",
-            "text": "You shall not commit adultery. (Ex 20:14)",
-            "description": "You shall not commit adultery. (Ex 20:14) The capital sin of lust breaks this commandment."
-        },
-        "7": {
-            "title": "Seventh Commandment",
-            "text": "You shall not steal. (Ex 20:15)",
-            "description": "You shall not steal. (Ex 20:15) The capital sins of greed and sloth are often considered to break this commandment."
-        },
-        "8": {
-            "title": "Eighth Commandment",
-            "text": "You shall not bear false witness against your neighbor. (Ex 20:16)",
-            "description": "You shall not bear false witness against your neighbor. (Ex 20:16)"
-        },
-        "9": {
-            "title": "Ninth Commandment",
-            "text": "You shall not covet your neighbor's wife. (Ex 20:17)",
-            "description": "You shall not covet your neighbor's wife. (Ex 20:17) The capital sin of jealousy can break this commandment."
-        },
-        "10": {
-            "title": "Tenth Commandment",
-            "text": "You shall not covet your neighbor's goods. (Ex 20:17)",
-            "description": "You shall not covet your neighbor's house… or his manservant, or his maidservant, or his ox, or his ass, or anything that is your neighbor's. (Ex 20:17) The capital sin of jealousy can break this commandment."
-        },
-        "11": {
-            "title": "Precepts of the Church",
-            "text": "The precepts of the Catholic Church are the minimum requirements that all Catholics should fulfill.",
-            "description": "The precepts of the Church are set in the context of a moral life bound to and nourished by liturgical life. The obligatory character of these positive laws decreed by the pastoral authorities is meant to guarantee to the faithful the very necessary minimum in the spirit of prayer and moral effort, in the growth in love of God and neighbor (CCC 2041)."
-        }
+    "9": {
+      "title": "Ninth Commandment",
+      "text": "You shall not covet your neighbor's wife. (Ex 20:17)",
+      "description": "You shall not covet your neighbor's wife. (Ex 20:17) The capital sin of jealousy can break this commandment."
     },
-    "sins": {
-        "1": {
-            "text": "Did I refuse to believe the teachings of the Catholic Church?",
-            "text_past": "I refused to believe the teachings of the Catholic Church.",
-            "detail": "To obey in faith is to submit freely to the word that has been heard, because its truth is guaranteed by God, who is Truth itself (CCC 144). It is important to believe in all of the teachings of the church."
-        },
-        "2": {
-            "text": "Did I practice any religion besides Catholicism?",
-            "text_past": "I practiced a religion besides Catholicism.",
-            "detail": "The first commandment forbids honoring gods other than the one Lord who has revealed himself to his people (CCC 2110).  It is wrong to practice a religion other than Catholicism because it weakens our relationship with our Lord."
-        },
-        "3": {
-            "text": "Did I presume God's mercy?",
-            "text_past": "I presumed God's mercy.",
-            "detail": "Presuming God's mercy is hoping to obtain forgiveness without conversion and glory without merit (CCC 2092). It is wrong to do something immoral because you expect God to forgive you."
-        },
-        "4": {
-            "text": "How is my prayer life?  Do I need to pray more often?",
-            "text_past": "I need to pray more often.",
-            "detail": "Adoring God, praying to him, offering him the worship that belongs to him, fulfilling the promises and vows made to him are acts of the virtue of religionwhich fall under obedience to the first commandment (CCC 2135). Prayer is important because without prayer we cannot have a relationship with God."
-        },
-        "5": {
-            "text": "Our culture often conflicts with Catholic ideals.  Did I fail to stand up for Catholic moral values?",
-            "text_past": "I failed to stand up for Catholic moral values.",
-            "detail": ""
-        },
-        "6": {
-            "text": "Did I use foul language?",
-            "text_past": "I used foul language.",
-            "detail": ""
-        },
-        "7": {
-            "text": "Did I use God's name without respect?",
-            "text_past": "I used God's name without respect.",
-            "detail": "The second commandment forbids every improper use of God's name. Blasphemy is the use of the name of God, of Jesus Christ, of the Virgin Mary, and of the saints in an offensive way (CCC 2162)."
-        },
-        "8": {
-            "text": "Did I insult God?",
-            "text_past": "I insulted God.",
-            "detail": "Respect for His name is an expression of the respect owed to the mystery of God himself and to the whole sacred reality it evokes (CCC 2144)."
-        },
-        "9": {
-            "text": "Did I skip mass on Sunday?",
-            "text_past": "I skipped mass on Sunday.",
-            "detail": "The first precept of the Catholic church is \"You shall attend Mass on Sundays and holy days of obligation and rest from servile labor\" (CCC 2042).  As Catholics, we look forward to celebrating the Eucharist every Sunday. It is a sin to skip mass because it weakens our relationship with God."
-        },
-        "10": {
-            "text": "Did I skip mass on a holy day of obligation?",
-            "text_past": "I skipped mass on a holy day of obligation.",
-            "detail": "The first precept of the Catholic church is \"You shall attend Mass on Sundays and holy days of obligation and rest from servile labor\" (CCC 2042).  As Catholics, we look forward to celebrating the Eucharist on holy days of obligation. It is a sin to skip mass because it weakens our relationship with God."
-        },
-        "11": {
-            "text": "Did I arrive to mass late or leave early?",
-            "text_past": "I arrived to mass late or left early.",
-            "detail": "Come to church early, approach the Lord, and confess your sins, repent in prayer… Be present at the sacred and divine liturgy, conclude its prayer and do not leave before dismissal… (CCC 2178). It is also rude and distracting to others who are worshipping to arrive late or leave early."
-        },
-        "12": {
-            "text": "Did I disobey my parents?",
-            "text_past": "I disobeyed my parents.",
-            "detail": ""
-        },
-        "13": {
-            "text": "Did I fail to raise my children in the Catholic faith?",
-            "text_past": "I failed to raise my children in the Catholic faith.",
-            "detail": ""
-        },
-        "14": {
-            "text": "Did I fail to care for my elderly relatives?",
-            "text_past": "I failed to care for my elderly relatives.",
-            "detail": ""
-        },
-        "15": {
-            "text": "Did I neglect my family?",
-            "text_past": "I neglected my family.",
-            "detail": ""
-        },
-        "16": {
-            "text": "Did I disobey any responsible adult?",
-            "text_past": "I disobeyed a responsible adult.",
-            "detail": ""
-        },
-        "17": {
-            "text": "Did I fail to teach my children about their human sexuality?",
-            "text_past": "I failed to teach my children about their human sexuality.",
-            "detail": ""
-        },
-        "18": {
-            "text": "Did I break a just law?",
-            "text_past": "I broke a just law.",
-            "detail": ""
-        },
-        "19": {
-            "text": "Did I physically hurt anyone?",
-            "text_past": "I physically hurt someone.",
-            "detail": ""
-        },
-        "20": {
-            "text": "Did I have an abortion?  Did I participate in an abortion?",
-            "text_past": "I had or participated in an abortion.",
-            "detail": ""
-        },
-        "21": {
-            "text": "Did I use artificial birth control?",
-            "text_past": "I used artificial birth control.",
-            "detail": "\"Every action which, whether in anticipation of the conjugal act, or in its accomplishment, or in the development of its natural consequences, proposes, whether as an end or as a means, to render procreation impossible is intrinsically evil\" (CCC 2370). \"Legitimate intentions on the part of the spouses do not justify recourse to morally unacceptable means (for example, direct sterilization or contraception)\" (CCC 2399). Artificial contraception is wrong because it makes a beautiful act of love into something selfish."
-        },
-        "22": {
-            "text": "Did I attempt suicide?",
-            "text_past": "I attempted suicide.",
-            "detail": ""
-        },
-        "23": {
-            "text": "Did I participate in euthanasia?",
-            "text_past": "I participated in Euthanasia.",
-            "detail": ""
-        },
-        "24": {
-            "text": "Did I abuse drugs or alcohol?",
-            "text_past": "I abused drugs or alcohol.",
-            "detail": ""
-        },
-        "25": {
-            "text": "Did I have sex outside marriage?",
-            "text_past": "I had sex outside marriage.",
-            "detail": ""
-        },
-        "26": {
-            "text": "Am I guilty of the sin of lust?",
-            "text_past": "I am guilty of the sin of lust.",
-            "detail": ""
-        },
-        "27": {
-            "text": "Did I look at pornography?",
-            "text_past": "I looked at pornography.",
-            "detail": ""
-        },
-        "28": {
-            "text": "Did I act on homosexual desires?",
-            "text_past": "I acted on homosexual desires.",
-            "detail": ""
-        },
-        "29": {
-            "text": "Did I fail to honor my husband or wife?",
-            "text_past": "I failed to honor my husband or wife.",
-            "detail": ""
-        },
-        "30": {
-            "text": "Did I read erotic literature?",
-            "text_past": "I read erotic literature.",
-            "detail": ""
-        },
-        "31": {
-            "text": "Did I engage in sexually immoral acts?",
-            "text_past": "I engaged in sexually immoral acts.",
-            "detail": ""
-        },
-        "32": {
-            "text": "Did I give in to overly passionate kissing for pleasure?",
-            "text_past": "I gave in to overly passionate kissing for pleasure.",
-            "detail": ""
-        },
-        "33": {
-            "text": "Did I steal anything? If so, to what extent?",
-            "text_past": "I stole something. (To such and such an extent.)",
-            "detail": ""
-        },
-        "34": {
-            "text": "Did I pirate movies, music, or software?",
-            "text_past": "I pirated movies, music, or software.",
-            "detail": ""
-        },
-        "35": {
-            "text": "Did I lie or cheat?",
-            "text_past": "I lied or cheated.",
-            "detail": ""
-        },
-        "36": {
-            "text": "Did I gossip about others?",
-            "text_past": "I gossiped about others.",
-            "detail": ""
-        },
-        "37": {
-            "text": "Did I fail to fast on Ash Wednesday and Good Friday?",
-            "text_past": "I failed to fast on Ash Wednesday or Good Friday.",
-            "detail": ""
-        },
-        "38": {
-            "text": "Did I fail to abstain from meat on Fridays of Lent and Ash Wednesday?",
-            "text_past": "I failed to abstain from meat on a Friday during Lent or Ash Wednesday.",
-            "detail": ""
-        },
-        "39": {
-            "text": "Did I fail to receive the Eucharist at least once during Easter?",
-            "text_past": "I failed to receive the Eucharist at least once during Easter.",
-            "detail": ""
-        },
-        "40": {
-            "text": "Did I fail to fast for an hour before receiving the Eucharist?",
-            "text_past": "I failed to fast for an hour before receiving the Eucharist.",
-            "detail": ""
-        },
-        "41": {
-            "text": "Did I receive the Eucharist in a state of mortal sin?",
-            "text_past": "I received the Eucharist in a state of mortal sin.",
-            "detail": ""
-        },
-        "42": {
-            "text": "Did I intentionally hide something at confession?",
-            "text_past": "I intentionally hid something at confession.",
-            "detail": ""
-        },
-        "43": {
-            "text": "Was I too busy to rest and spend time with my family on Sunday?",
-            "text_past": "I was too busy to rest and spend time with my family on Sunday.",
-            "detail": ""
-        },
-        "44": {
-            "text": "Was I jealous of someone else's wife/husband or fiancée/fiancé?",
-            "text_past": "I was jealous of someone else's wife/husband or fiancée/fiancé.",
-            "detail": ""
-        },
-        "45": {
-            "text": "Was I jealous of something that belongs to someone else?",
-            "text_past": "I was jealous of something that belongs to someone else.",
-            "detail": ""
-        },
-        "46": {
-            "text": "Did I vote for a candidate or policy that does not uphold my Catholic values?",
-            "text_past": "I voted for a candidate or policy that does not uphold my Catholic values.",
-            "detail": ""
-        },
-        "47": {
-            "text": "Did I listen to music or watch TV or a movie that have a bad influence on me?",
-            "text_past": "I listened to music or watched TV or a movie that had a bad influence on me.",
-            "detail": ""
-        },
-        "48": {
-            "text": "Was I greedy, or did I fail to give generously to my church and to the poor?",
-            "text_past": "I was greedy or failed to give generously to my church or to the poor.",
-            "detail": ""
-        },
-        "49": {
-            "text": "Did I knowingly lead others into sin?",
-            "text_past": "I knowingly led others into sin.",
-            "detail": ""
-        },
-        "50": {
-            "text": "Did I fail to make God a priority in my life?",
-            "text_past": "I failed to make God a priority in my life.",
-            "detail": ""
-        },
-        "51": {
-            "text": "Have I acted selfishly?",
-            "text_past": "I acted selfishly.",
-            "detail": ""
-        },
-        "52": {
-            "text": "Did I participate in occult practices?",
-            "text_past": "I participated in occult practices.",
-            "detail": ""
-        },
-        "53": {
-            "text": "Have I been slothful at work or at home?",
-            "text_past": "I was slothful at work or at home.",
-            "detail": ""
-        },
-        "54": {
-            "text": "Have I been lazy with my school work?",
-            "text_past": "I was lazy with my school work.",
-            "detail": ""
-        },
-        "55": {
-            "text": "Have I been prideful or vain?",
-            "text_past": "I was prideful or vain.",
-            "detail": ""
-        },
-        "56": {
-            "text": "Have I committed the sin of gluttony?",
-            "text_past": "I am guilty of gluttony.",
-            "detail": ""
-        },
-        "57": {
-            "text": "Have I allowed myself to be controlled by anger?",
-            "text_past": "I allowed myself to be controlled by anger.",
-            "detail": ""
-        }
+    "10": {
+      "title": "Tenth Commandment",
+      "text": "You shall not covet your neighbor's goods. (Ex 20:17)",
+      "description": "You shall not covet your neighbor's house… or his manservant, or his maidservant, or his ox, or his ass, or anything that is your neighbor's. (Ex 20:17) The capital sin of jealousy can break this commandment."
+    },
+    "11": {
+      "title": "Precepts of the Church",
+      "text": "The precepts of the Catholic Church are the minimum requirements that all Catholics should fulfill.",
+      "description": "The precepts of the Church are set in the context of a moral life bound to and nourished by liturgical life. The obligatory character of these positive laws decreed by the pastoral authorities is meant to guarantee to the faithful the very necessary minimum in the spirit of prayer and moral effort, in the growth in love of God and neighbor (CCC 2041)."
     }
+  },
+  "sins": {
+    "1": {
+      "text": "Did I refuse to believe the teachings of the Catholic Church?",
+      "text_past": "I refused to believe the teachings of the Catholic Church.",
+      "detail": "To obey in faith is to submit freely to the word that has been heard, because its truth is guaranteed by God, who is Truth itself (CCC 144). It is important to believe in all of the teachings of the church."
+    },
+    "2": {
+      "text": "Did I practice any religion besides Catholicism?",
+      "text_past": "I practiced a religion besides Catholicism.",
+      "detail": "The first commandment forbids honoring gods other than the one Lord who has revealed himself to his people (CCC 2110).  It is wrong to practice a religion other than Catholicism because it weakens our relationship with our Lord."
+    },
+    "3": {
+      "text": "Did I presume God's mercy?",
+      "text_past": "I presumed God's mercy.",
+      "detail": "Presuming God's mercy is hoping to obtain forgiveness without conversion and glory without merit (CCC 2092). It is wrong to do something immoral because you expect God to forgive you."
+    },
+    "4": {
+      "text": "How is my prayer life?  Do I need to pray more often?",
+      "text_past": "I need to pray more often.",
+      "detail": "Adoring God, praying to him, offering him the worship that belongs to him, fulfilling the promises and vows made to him are acts of the virtue of religionwhich fall under obedience to the first commandment (CCC 2135). Prayer is important because without prayer we cannot have a relationship with God."
+    },
+    "5": {
+      "text": "Our culture often conflicts with Catholic ideals.  Did I fail to stand up for Catholic moral values?",
+      "text_past": "I failed to stand up for Catholic moral values.",
+      "detail": ""
+    },
+    "6": {
+      "text": "Did I use foul language?",
+      "text_past": "I used foul language.",
+      "detail": ""
+    },
+    "7": {
+      "text": "Did I use God's name without respect?",
+      "text_past": "I used God's name without respect.",
+      "detail": "The second commandment forbids every improper use of God's name. Blasphemy is the use of the name of God, of Jesus Christ, of the Virgin Mary, and of the saints in an offensive way (CCC 2162)."
+    },
+    "8": {
+      "text": "Did I insult God?",
+      "text_past": "I insulted God.",
+      "detail": "Respect for His name is an expression of the respect owed to the mystery of God himself and to the whole sacred reality it evokes (CCC 2144)."
+    },
+    "9": {
+      "text": "Did I skip mass on Sunday?",
+      "text_past": "I skipped mass on Sunday.",
+      "detail": "The first precept of the Catholic church is \"You shall attend Mass on Sundays and holy days of obligation and rest from servile labor\" (CCC 2042).  As Catholics, we look forward to celebrating the Eucharist every Sunday. It is a sin to skip mass because it weakens our relationship with God."
+    },
+    "10": {
+      "text": "Did I skip mass on a holy day of obligation?",
+      "text_past": "I skipped mass on a holy day of obligation.",
+      "detail": "The first precept of the Catholic church is \"You shall attend Mass on Sundays and holy days of obligation and rest from servile labor\" (CCC 2042).  As Catholics, we look forward to celebrating the Eucharist on holy days of obligation. It is a sin to skip mass because it weakens our relationship with God."
+    },
+    "11": {
+      "text": "Did I arrive to mass late or leave early?",
+      "text_past": "I arrived to mass late or left early.",
+      "detail": "Come to church early, approach the Lord, and confess your sins, repent in prayer… Be present at the sacred and divine liturgy, conclude its prayer and do not leave before dismissal… (CCC 2178). It is also rude and distracting to others who are worshipping to arrive late or leave early."
+    },
+    "12": {
+      "text": "Did I disobey my parents?",
+      "text_past": "I disobeyed my parents.",
+      "detail": ""
+    },
+    "13": {
+      "text": "Did I fail to raise my children in the Catholic faith?",
+      "text_past": "I failed to raise my children in the Catholic faith.",
+      "detail": ""
+    },
+    "14": {
+      "text": "Did I fail to care for my elderly relatives?",
+      "text_past": "I failed to care for my elderly relatives.",
+      "detail": ""
+    },
+    "15": {
+      "text": "Did I neglect my family?",
+      "text_past": "I neglected my family.",
+      "detail": ""
+    },
+    "16": {
+      "text": "Did I disobey any responsible adult?",
+      "text_past": "I disobeyed a responsible adult.",
+      "detail": ""
+    },
+    "17": {
+      "text": "Did I fail to teach my children about their human sexuality?",
+      "text_past": "I failed to teach my children about their human sexuality.",
+      "detail": ""
+    },
+    "18": {
+      "text": "Did I break a just law?",
+      "text_past": "I broke a just law.",
+      "detail": ""
+    },
+    "19": {
+      "text": "Did I physically hurt anyone?",
+      "text_past": "I physically hurt someone.",
+      "detail": ""
+    },
+    "20": {
+      "text": "Did I have an abortion?  Did I participate in an abortion?",
+      "text_past": "I had or participated in an abortion.",
+      "detail": ""
+    },
+    "21": {
+      "text": "Did I use artificial birth control?",
+      "text_past": "I used artificial birth control.",
+      "detail": "\"Every action which, whether in anticipation of the conjugal act, or in its accomplishment, or in the development of its natural consequences, proposes, whether as an end or as a means, to render procreation impossible is intrinsically evil\" (CCC 2370). \"Legitimate intentions on the part of the spouses do not justify recourse to morally unacceptable means (for example, direct sterilization or contraception)\" (CCC 2399). Artificial contraception is wrong because it makes a beautiful act of love into something selfish."
+    },
+    "22": {
+      "text": "Did I attempt suicide?",
+      "text_past": "I attempted suicide.",
+      "detail": ""
+    },
+    "23": {
+      "text": "Did I participate in euthanasia?",
+      "text_past": "I participated in Euthanasia.",
+      "detail": ""
+    },
+    "24": {
+      "text": "Did I abuse drugs or alcohol?",
+      "text_past": "I abused drugs or alcohol.",
+      "detail": ""
+    },
+    "25": {
+      "text": "Did I have sex outside marriage?",
+      "text_past": "I had sex outside marriage.",
+      "detail": ""
+    },
+    "26": {
+      "text": "Am I guilty of the sin of lust?",
+      "text_past": "I am guilty of the sin of lust.",
+      "detail": ""
+    },
+    "27": {
+      "text": "Did I look at pornography?",
+      "text_past": "I looked at pornography.",
+      "detail": ""
+    },
+    "28": {
+      "text": "Did I act on homosexual desires?",
+      "text_past": "I acted on homosexual desires.",
+      "detail": ""
+    },
+    "29": {
+      "text": "Did I fail to honor my husband or wife?",
+      "text_past": "I failed to honor my husband or wife.",
+      "detail": ""
+    },
+    "30": {
+      "text": "Did I read erotic literature?",
+      "text_past": "I read erotic literature.",
+      "detail": ""
+    },
+    "31": {
+      "text": "Did I engage in sexually immoral acts?",
+      "text_past": "I engaged in sexually immoral acts.",
+      "detail": ""
+    },
+    "32": {
+      "text": "Did I give in to overly passionate kissing for pleasure?",
+      "text_past": "I gave in to overly passionate kissing for pleasure.",
+      "detail": ""
+    },
+    "33": {
+      "text": "Did I steal anything? If so, to what extent?",
+      "text_past": "I stole something. (To such and such an extent.)",
+      "detail": ""
+    },
+    "34": {
+      "text": "Did I pirate movies, music, or software?",
+      "text_past": "I pirated movies, music, or software.",
+      "detail": ""
+    },
+    "35": {
+      "text": "Did I lie or cheat?",
+      "text_past": "I lied or cheated.",
+      "detail": ""
+    },
+    "36": {
+      "text": "Did I gossip about others?",
+      "text_past": "I gossiped about others.",
+      "detail": ""
+    },
+    "37": {
+      "text": "Did I fail to fast on Ash Wednesday and Good Friday?",
+      "text_past": "I failed to fast on Ash Wednesday or Good Friday.",
+      "detail": ""
+    },
+    "38": {
+      "text": "Did I fail to abstain from meat on Fridays of Lent and Ash Wednesday?",
+      "text_past": "I failed to abstain from meat on a Friday during Lent or Ash Wednesday.",
+      "detail": ""
+    },
+    "39": {
+      "text": "Did I fail to receive the Eucharist at least once during Easter?",
+      "text_past": "I failed to receive the Eucharist at least once during Easter.",
+      "detail": ""
+    },
+    "40": {
+      "text": "Did I fail to fast for an hour before receiving the Eucharist?",
+      "text_past": "I failed to fast for an hour before receiving the Eucharist.",
+      "detail": ""
+    },
+    "41": {
+      "text": "Did I receive the Eucharist in a state of mortal sin?",
+      "text_past": "I received the Eucharist in a state of mortal sin.",
+      "detail": ""
+    },
+    "42": {
+      "text": "Did I intentionally hide something at confession?",
+      "text_past": "I intentionally hid something at confession.",
+      "detail": ""
+    },
+    "43": {
+      "text": "Was I too busy to rest and spend time with my family on Sunday?",
+      "text_past": "I was too busy to rest and spend time with my family on Sunday.",
+      "detail": ""
+    },
+    "44": {
+      "text": "Was I jealous of someone else's wife/husband or fiancée/fiancé?",
+      "text_past": "I was jealous of someone else's wife/husband or fiancée/fiancé.",
+      "detail": ""
+    },
+    "45": {
+      "text": "Was I jealous of something that belongs to someone else?",
+      "text_past": "I was jealous of something that belongs to someone else.",
+      "detail": ""
+    },
+    "46": {
+      "text": "Did I vote for a candidate or policy that does not uphold my Catholic values?",
+      "text_past": "I voted for a candidate or policy that does not uphold my Catholic values.",
+      "detail": ""
+    },
+    "47": {
+      "text": "Did I listen to music or watch TV or a movie that have a bad influence on me?",
+      "text_past": "I listened to music or watched TV or a movie that had a bad influence on me.",
+      "detail": ""
+    },
+    "48": {
+      "text": "Was I greedy, or did I fail to give generously to my church and to the poor?",
+      "text_past": "I was greedy or failed to give generously to my church or to the poor.",
+      "detail": ""
+    },
+    "49": {
+      "text": "Did I knowingly lead others into sin?",
+      "text_past": "I knowingly led others into sin.",
+      "detail": ""
+    },
+    "50": {
+      "text": "Did I fail to make God a priority in my life?",
+      "text_past": "I failed to make God a priority in my life.",
+      "detail": ""
+    },
+    "51": {
+      "text": "Have I acted selfishly?",
+      "text_past": "I acted selfishly.",
+      "detail": ""
+    },
+    "52": {
+      "text": "Did I participate in occult practices?",
+      "text_past": "I participated in occult practices.",
+      "detail": ""
+    },
+    "53": {
+      "text": "Have I been slothful at work or at home?",
+      "text_past": "I was slothful at work or at home.",
+      "detail": ""
+    },
+    "54": {
+      "text": "Have I been lazy with my school work?",
+      "text_past": "I was lazy with my school work.",
+      "detail": ""
+    },
+    "55": {
+      "text": "Have I been prideful or vain?",
+      "text_past": "I was prideful or vain.",
+      "detail": ""
+    },
+    "56": {
+      "text": "Have I committed the sin of gluttony?",
+      "text_past": "I am guilty of gluttony.",
+      "detail": ""
+    },
+    "57": {
+      "text": "Have I allowed myself to be controlled by anger?",
+      "text_past": "I allowed myself to be controlled by anger.",
+      "detail": ""
+    }
+  },
+  "addbutton": {
+    "add-custom-sin": "",
+    "i-sinned-by": "",
+    "cancel": "",
+    "add": ""
+  },
+  "examineitem": {
+    "yes": ""
+  },
+  "priestbubble": {
+    "priest": ""
+  }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -57,13 +57,13 @@
     "privacy": "Privacy",
     "information_you_enter": "Information you enter into this app is only stored on your device. It is not sent over the internet. We are able to do this using a technology provided by your web browser called <a>local storage</a>. We do not run Google Analytics or any other data collection mechanism on this site. Data you enter will be saved on your device until you hit <kbd>Clear</kbd> even if you close the window or refresh the page.",
     "open_source": "Open Source",
-    "confessit_is_open_source": "ConfessIt is open source. We develop the app on <i></i> <github>GitHub</github> and we collaborate in the <osc>Open Source Catholic</osc> community on Slack.",
+    "confessit_is_open_source": "ConfessIt is open source. We develop the app on <githubicon /> <github>GitHub</github> and we collaborate in the <osc>Open Source Catholic</osc> community on Slack.",
     "can_i_help_with_translations": "Can I help with translations?",
     "confessit_is_translated": "ConfessIt is translated into multiple languages. If you'd like to help with this effort by adding a new translation or improving an existing translation, please read about how to do so on <github>GitHub</github> or get in touch with us on <osc>Open Source Catholic</osc> Slack.",
     "can_i_help_write_code": "Can I help write code?",
-    "we_welcome_new_contributions": "We welcome new contributions. If you'd like to contribute to ConfessIt, the best way to begin is by reading about how to do so on <1>GitHub</1>.",
+    "we_welcome_new_contributions": "We welcome new contributions. If you'd like to contribute to ConfessIt, the best way to begin is by reading about how to do so on <github>GitHub</github>.",
     "about_the_developer": "About the Developer",
-    "mike_kasberg": "<0>Mike Kasberg</0> develops ConfessIt in his free time, as a way of giving back to the church. He is also involved in a few other small projects to support Catholic organizations with technology.",
+    "mike_kasberg": "<website>Mike Kasberg</website> develops ConfessIt in his free time, as a way of giving back to the church. He is also involved in a few other small projects to support Catholic organizations with technology.",
     "information": "Bible quotes in this app come from the Revised Standard Version of the Holy Bible, Second Catholic Edition. Information from the Catechism of the Catholic Church was also used."
   },
   "help": {
@@ -146,7 +146,7 @@
     "2": {
       "text": "Did I practice any religion besides Catholicism?",
       "text_past": "I practiced a religion besides Catholicism.",
-      "detail": "The first commandment forbids honoring gods other than the one Lord who has revealed himself to his people (CCC 2110).  It is wrong to practice a religion other than Catholicism because it weakens our relationship with our Lord."
+      "detail": "The first commandment forbids honoring gods other than the one Lord who has revealed himself to his people (CCC 2110). It is wrong to practice a religion other than Catholicism because it weakens our relationship with our Lord."
     },
     "3": {
       "text": "Did I presume God's mercy?",
@@ -154,12 +154,12 @@
       "detail": "Presuming God's mercy is hoping to obtain forgiveness without conversion and glory without merit (CCC 2092). It is wrong to do something immoral because you expect God to forgive you."
     },
     "4": {
-      "text": "How is my prayer life?  Do I need to pray more often?",
+      "text": "How is my prayer life? Do I need to pray more often?",
       "text_past": "I need to pray more often.",
       "detail": "Adoring God, praying to him, offering him the worship that belongs to him, fulfilling the promises and vows made to him are acts of the virtue of religionwhich fall under obedience to the first commandment (CCC 2135). Prayer is important because without prayer we cannot have a relationship with God."
     },
     "5": {
-      "text": "Our culture often conflicts with Catholic ideals.  Did I fail to stand up for Catholic moral values?",
+      "text": "Our culture often conflicts with Catholic ideals. Did I fail to stand up for Catholic moral values?",
       "text_past": "I failed to stand up for Catholic moral values.",
       "detail": ""
     },
@@ -181,12 +181,12 @@
     "9": {
       "text": "Did I skip mass on Sunday?",
       "text_past": "I skipped mass on Sunday.",
-      "detail": "The first precept of the Catholic church is \"You shall attend Mass on Sundays and holy days of obligation and rest from servile labor\" (CCC 2042).  As Catholics, we look forward to celebrating the Eucharist every Sunday. It is a sin to skip mass because it weakens our relationship with God."
+      "detail": "The first precept of the Catholic church is \"You shall attend Mass on Sundays and holy days of obligation and rest from servile labor\" (CCC 2042). As Catholics, we look forward to celebrating the Eucharist every Sunday. It is a sin to skip mass because it weakens our relationship with God."
     },
     "10": {
       "text": "Did I skip mass on a holy day of obligation?",
       "text_past": "I skipped mass on a holy day of obligation.",
-      "detail": "The first precept of the Catholic church is \"You shall attend Mass on Sundays and holy days of obligation and rest from servile labor\" (CCC 2042).  As Catholics, we look forward to celebrating the Eucharist on holy days of obligation. It is a sin to skip mass because it weakens our relationship with God."
+      "detail": "The first precept of the Catholic church is \"You shall attend Mass on Sundays and holy days of obligation and rest from servile labor\" (CCC 2042). As Catholics, we look forward to celebrating the Eucharist on holy days of obligation. It is a sin to skip mass because it weakens our relationship with God."
     },
     "11": {
       "text": "Did I arrive to mass late or leave early?",
@@ -234,7 +234,7 @@
       "detail": ""
     },
     "20": {
-      "text": "Did I have an abortion?  Did I participate in an abortion?",
+      "text": "Did I have an abortion? Did I participate in an abortion?",
       "text_past": "I had or participated in an abortion.",
       "detail": ""
     },

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -73,15 +73,29 @@
     "step_4": "Despues de la confesión, usa el boton <strong>Borrar</strong> para vaciar todos los pecados demarcados.",
     "step_2": "Desliza a la siguiente pestaña, <strong>Pecados</strong>, para ver la lista de los pecados que has marcado. Puedes revisar esta lista antes o durante la confesión si lo deseas.",
     "step_3": "Si no estas seguro de lo qué vas a decir en la confesión, pasa a la siguiente pestaña, <strong>Tutorial </strong>, para ver aproximadamente lo que tu y el sacerdote se dirán en la confesión. Puedes revisar esto durante la confesión si lo deseas.",
-    "data_persistence_text": "Los datos que vas ad ingresar se almacenan en tu dispositivo (nunca se envían a través de Internet). Los datos que ingreses se guardarán hasta que presiones <strong>Borrar</strong>, incluso si cierras la ventana o actualizas la página. ¡Asegúrete de borrar tus datos cuando haya terminado si no deseas que otras personas que usan este dispositivo vean tus datos!"
+    "data_persistence_text": "Los datos que vas ad ingresar se almacenan en tu dispositivo (nunca se envían a través de Internet). Los datos que ingreses se guardarán hasta que presiones <strong>Borrar</strong>, incluso si cierras la ventana o actualizas la página. ¡Asegúrete de borrar tus datos cuando haya terminado si no deseas que otras personas que usan este dispositivo vean tus datos!",
+    "step_1": "In the <1>Examination</1> tab, mark <4>Yes</4> next to all the sins you want to remember to confess."
   },
   "welcome": {
-    "title": "¡Bienvenido!"
+    "title": "¡Bienvenido!",
+    "body": "is a tool to help Roman Catholics walk through an examination of conscience prior to going to confession. We hope you'll find this useful to help remember sins you've committed since your last confession. Just check the <1>Yes</1> box next to sins in the <3>Examine</3> list, or tap the plus button to add your own. Then, scroll to the right to <5>Review</5> your sins and <7>Walkthrough</7> the steps of going to confession.<9></9><10></10>Data you enter is stored on your device (<12>never</12> sent over the Internet). Data you enter will be saved until you hit <15>Clear</15>, even if you close the window or refresh the page.<17></17><18></18>God bless you on your path to holiness!"
   },
   "commandments": {
     "1": {
       "title": "Primer Mandamiento",
       "text": "Yo soy el Señor tu Dios. No habrá para ti otros dioses delante de mí. (Éx 20,3)"
     }
+  },
+  "addbutton": {
+    "add-custom-sin": "",
+    "i-sinned-by": "",
+    "cancel": "",
+    "add": ""
+  },
+  "examineitem": {
+    "yes": ""
+  },
+  "priestbubble": {
+    "priest": ""
   }
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -1,427 +1,439 @@
 {
-    "navbar": {
-        "prayers": "Preghiere",
-        "help": "Aiuto",
-        "about": "Su questa app",
-        "clear": "Svuota"
+  "navbar": {
+    "prayers": "Preghiere",
+    "help": "Aiuto",
+    "about": "Su questa app",
+    "clear": "Svuota"
+  },
+  "examine_list": {
+    "examine": "Esamina"
+  },
+  "sins_list": {
+    "review": "Revisiona"
+  },
+  "walkthrough": {
+    "walkthrough": "Confessa",
+    "in_the_name_of": "Nel nome del Padre, e del Figlio, e dello Spirito Santo. Amen.",
+    "bless_me_father": "Benedicimi Padre, perché ho peccato. Sono ____ dall'ultima confessione. Questi sono i miei peccati:",
+    "these_are_my_sins": "Questi sono i miei peccati, e me ne pento con tutto il cuore.",
+    "your_confessor_may_offer": "(Il confessore può ora offrire dei consigli o intrattenere una breve conversazione.)",
+    "your_confessor_will_assign": "(Il confessore ti assegnerà una penitenza da adempiere.) Ora recita l'atto di dolore.",
+    "act_of_contrition": "<p>Mio Dio, mi pento e mi dolgo con tutto il cuore dei miei peccati.</p><p>Perché peccando ho meritato i tuoi castighi, e molto più perché ho offeso te, infinitamente buono e degno di essere amato sopra ogni cosa.</p><p>Propongo con il tuo santo aiuto di non offenderti mai più, e di fuggire le occasioni prossime di peccato.</p><p>Signore, misericordia, perdonami.</p>",
+    "god_the_father_of_mercies": "Dio, Padre di misericordia…",
+    "amen": "Amen.",
+    "the_lord_has_freed_you": "Il Signore ha perdonato i tuoi peccati. Va' in pace.",
+    "thanks_be_to_god": "Lodiamo il Signore perché è buono."
+  },
+  "prayers": {
+    "prayers": "Preghiere",
+    "prayer_before_confession": "Preghiera prima della Confessione",
+    "act_of_contrition": "Atto di Dolore",
+    "another_act_of_contrition": "Altro Atto di Dolore",
+    "thanksgiving_after_confession": "Ringraziamento dopo la Confessione",
+    "our_father": "Padre Nostro",
+    "hail_mary": "Ave Maria",
+    "hail_holy_queen": "Salve Regina",
+    "prayer_before_confession_text": "<p>Padre santo, come il figliol prodigo mi rivolgo alla tua misericordia:<br />«Ho peccato contro di te, non son più degno d'esser chiamato tuo figlio ».<br />Cristo Gesù, Salvatore del mondo, che hai aperto al buon ladrone le porte del paradiso, ricordati di me nel tuo regno.<br />Spirito Santo, sorgente di pace e d'amore, fa' che purificato da ogni colpa e riconciliato con il Padre io cammini sempre come figlio della luce.<br />Amen.</p>",
+    "act_of_contrition_text": "<p>Ricordati, Signore, del tuo amore,<br />della tua fedeltà che è da sempre.<br />Non ricordare i miei peccati:<br />ricordati di me nella tua misericordia,<br />per la tua bontà, Signore.</p>",
+    "another_act_of_contrition_text": "<p>Lavami, Signore, da tutte le mie colpe,<br />mondami dal mio peccato.<br />Riconosco la mia colpa,<br />il mio peccato mi sta sempre dinanzi.<br />Amen.</p>",
+    "thanksgiving_after_confession_text": "<p>Dio mio, Padre dolcissimo, com'è dolce la tua grazia, com'è grande il tuo amore! Hai perdonato tutti i miei peccati e mi hai fatto assaporare di nuovo le meraviglie del tuo amore. Ti ringraziano per me, o mio Dio, il Cielo e la terra ed io do voce a tutte le creature per lodarti e ringraziarti per sempre. Ti ringraziano le Anime del Purgatorio, per le quali ora Ti saranno più accette le mie preghiere, poiché ho l'anima purificata da ogni peccato e sono di nuovo tuo amico.<br />Per mostrarti la mia riconoscenza, o Signore, come meglio posso, Ti offro la promessa di voler evitare ad ogni costo il peccato.<br />Piuttosto, o mio Dio, scelgo il disprezzo del mondo, le mortificazioni e le pene, le tribolazioni di ogni tipo, ed anche la morte, ma mai più voglio trasgredire i tuoi precetti che sono consigli di Padre amorevole.<br />Per mezzo della santa assoluzione mi hai accolto ancora nel tuo abbraccio paterno, ed io non voglio più staccarmi da Te. <br />Amen.</p>",
+    "our_father_text": "<p>Padre nostro,<br />che sei nei cieli, sia santificato il Tuo nome;<br />venga il Tuo regno; sia fatta la Tua volontà, come in cielo così in terra.<br />Dàcci oggi il nostro pane quotidiano, e rimètti a noi i nostri debiti,<br />come anche noi li rimettiamo ai nostri debitori.<br />E non ci abbandonare alla tentazione, ma lìberaci dal male.<br />Amen.</p>",
+    "hail_mary_text": "<p>Ave Maria, piena di grazia.<br />Il Signore è con te.<br />Benedetta tu fra le donne, e benedtto il frutto del tuo seno, Gesù.<br />Santa Maria, madre di Dio,<br />prèga per noi peccatori, ora e nell'ora della nostra morte.<br />Amen.</p>",
+    "hail_holy_queen_text": "<p>Salve, Regina, madre di misericordia,<br />vita, dolcezza e speranza nostra, salve.<br />A te ricorriamo, esuli figli di Eva; a te sospiriamo, gementi e piangenti in questa valle di lacrime.<br />Orsù dunque, avvocata nostra, rivolgi a noi gli occhi tuoi misericordiosi.<br />E mostraci, dopo questo esilio, Gesù, il frutto benedetto del tuo Seno.<br />O clemente, o pia, o dolce Vergine Maria!</p>"
+  },
+  "about": {
+    "about_confessit": "Riguardo ConfessaLo",
+    "about_confessit_text": "ConfessIt è un esame di coscienza <vatican>Cattolico Romano</vatican> per computer, tablet, e smartphone. E' pensato per la facilità d'utilizzo, per essere di aiuto nel fare mente locale dei peccati da confessare. C'è anche una guida che ti segue passo passo nel rito della confessione, per aiutarti durante il rito. Una grande risorsa se non ti sei confessato da tempo! L'esame di coscienza si basa sugli insegnamenti della chiesa cattolica, è facile da comprendere, e risulta attuale per i cattolici di oggi.",
+    "about_confession": "Riguardo la Confessione",
+    "about_confession_intro": "La Confessione è il sacramento con il quale i Cattolici ottengono il perdono dei peccati dalla misericordia di Dio, e vengono così riconciliati con la Chiesa, la comunità dei credenti, il Corpo di Cristo.",
+    "ccc_quote": "<p>È chiamato sacramento della Conversione poiché realizza sacramentalmente l'appello di Gesù alla conversione,4 il cammino di ritorno al Padre (Cf Mc 1,15;Lc 15,18) da cui ci si è allontanati con il peccato.</p><p>È chiamato sacramento della Penitenza poiché consacra un cammino personale ed ecclesiale di conversione, di pentimento e di soddisfazione del cristiano peccatore.</p><p>È chiamato sacramento della Confessione poiché l'accusa, la confessione dei peccati davanti al sacerdote è un elemento essenziale di questo sacramento. In un senso profondo esso è anche una « confessione », riconoscimento e lode della santità di Dio e della sua misericordia verso l'uomo peccatore.</p><p>È chiamato sacramento del Perdono poiché, attraverso l'assoluzione sacramentale del sacerdote, Dio accorda al penitente « il perdono e la pace ». (Rito della Penitenza, 46. 55)</p><p>È chiamato sacramento della Riconciliazione perché dona al peccatore l'amore di Dio che riconcilia: « Lasciatevi riconciliare con Dio » (2 Cor 5,20). Colui che vive dell'amore misericordioso di Dio è pronto a rispondere all'invito del Signore: « Va' prima a riconciliarti con il tuo fratello » (Mt 5,24)</p><p>La conversione a Cristo, la nuova nascita dal Battesimo, il dono dello Spirito Santo, il Corpo e il Sangue di Cristo ricevuti in nutrimento, ci hanno resi « santi e immacolati al suo cospetto » (Ef 1,4), come la Chiesa stessa, Sposa di Cristo, è « santa e immacolata » (Ef 5,27) davanti a lui. Tuttavia, la vita nuova ricevuta nell'iniziazione cristiana non ha soppresso la fragilità e la debolezza della natura umana, né l'inclinazione al peccato che la tradizione chiama concupiscenza, la quale rimane nei battezzati perché sostengano le loro prove nel combattimento della vita cristiana, aiutati dalla grazia di Cristo. (Cf Concilio di Trento, Sess. 5a, Decretum de peccato originali, canone 5.) Si tratta del combattimento della conversione in vista della santità e della vita eterna alla quale il Signore non cessa di chiamarci.</p><p>Gesù chiama alla conversione. Questo appello è una componente essenziale dell'annuncio del Regno: « Il tempo è compiuto e il regno di Dio è ormai vicino; convertitevi e credete al Vangelo » (Mc 1,15). Il Battesimo è quindi il luogo principale della prima e fondamentale conversione, ma l'appello di Cristo alla conversione continua a risuonare nella vita dei cristiani. Questa seconda conversione è un impegno continuo per tutta la Chiesa che « comprende nel suo seno i peccatori » e che, « santa insieme e sempre bisognosa di purificazione, incessantemente si applica alla penitenza e al suo rinnovamento ». (Concilio Vaticano II, Cost. dogm. Lumen gentium, 8.) Questo sforzo di conversione non è soltanto un'opera umana. È il dinamismo del « cuore contrito » (Cf Sal 51,19) attirato e mosso dalla grazia (Cf Gv 6,44; 12,32) a rispondere all'amore misericordioso di Dio che ci ha amati per primo (Cf 1 Gv 4,10). A proposito delle due conversioni sant'Ambrogio dice: « La Chiesa ha l'acqua e le lacrime: l'acqua del Battesimo, le lacrime della Penitenza » (Sant'Ambrogio, Epistula extra collectionem, 1 [41], 12).</p><7>— Catechismo della Chiesa Cattolica 1423-1424,1426; cf. 1427-1429</7>",
+    "where_to_find": "Gli orari per la confessione sono elencati nel bollettino della tua parrocchia, o li puoi trovare sul sito della tua parrocchia oppure sul sito <mass>masstimes.org</mass>. Puoi anche prenotare una confessione rivolgendoti direttamente alla tua parrocchia.",
+    "about_confession_end": "Quando ti confessi, hai generalmente la scelta tra stare seduti a faccia a faccia con il confessore, o stare in ginocchio dietro una grata in maniera più anonima. Non c'è motivo per preoccuparsi nella confessione! Qualsiasi peccato potrai accusare, il sacerdote l'ha già ascoltato. Ricòrdati che il sacerdote è lì per te, per aiutarti, per il tuo bene.",
+    "about_this_app": "Riguardo quest'App",
+    "this_app_is_designed": "Quest'app è pensata per assistere i cattolici che desiderano confessarsi, nella fase dell'esame di coscienza prima della confessione. <strong>NON</strong> si tratta di un sostituto per la confessione.",
+    "please_be_respectful": "Si raccomanda avere un occhio di riguardo per coloro che possano stare nelle vicinanze quando fai uso dell'app. Si raccomanda di utilizzare l'app prima di giungere in chiesa, e di spegnere poi il telefono quando si è in chiesa. Se usi l'app dentro la chiesa o durante la confessione, assicùrati che il telefono sia in modalità silenziosa.",
+    "this_website": "Questo sito, <website>ConfessIt.app</website>, è basato sull'<app>App ConfessIt per Android</app> (creato nel 2012 dallo stesso sviluppatore). Mentre non è (ancora) una riproduzione completa, mira a rendere l'app maggiormente disponibile per più utenti su più dispositivi. (Questo sito funziona su iOS, Android, sia su tablet che su computer!)",
+    "if_you_find": "Se ti piace l'app, <strong>condivìdila</strong> con amici e parenti. Pàrlane su Facebook, Reddit, Twitter, in chiesa, o nel tuo gruppo di catechesi in modo da farla conoscere!",
+    "privacy": "Privacy",
+    "information_you_enter": "Le informazioni immesse nell'app sono immagazzinate soltanto sul tuo dispositivo. Non vengono trasmesse via internet. Questo è possibile grazie ad una tecnologia offerta dal browser, chiamata <a>local storage</a>. Non viene utilizzato alcun sistema di analisi dei dati, del tipo Google Analytics o qualsiasi altro sistema simile. I dati da te immessi permangono sul dispositivo anche se chiudi la finestra o aggiorni la pagina; vengono eliminati solo quando fai clic su <kbd>Svuota</kbd>.",
+    "open_source": "Sorgenti Aperte",
+    "confessit_is_open_source": "ConfessIt è un progetto informatico a sorgenti aperte (\"open source\"). Sviluppiamo l'app su <i></i> <github>GitHub</github> e collaboriamo nella comunità <osc>Open Source Catholic</osc> su Slack.",
+    "can_i_help_with_translations": "Posso aiutare con le traduzioni?",
+    "confessit_is_translated": "ConfessIt è tradotto in varie lingue. Se puoi aiutare in questo, aggiungendo una nuova traduzione o migliorando una traduzione già esistente, leggi su <github>GitHub</github> come fare per contribuire, oppure rivolgiti a noi nello spazio di lavoro <osc>Open Source Catholic</osc> su Slack.",
+    "can_i_help_write_code": "Posso aiutare a scrivere codice?",
+    "we_welcome_new_contributions": "Nuovi contributi sono benvenuti. Se vuoi contribuire allo sviluppo di ConfessaLo, inizia col leggere le istruzioni su <1>GitHub</1> per i contributi.",
+    "about_the_developer": "Riguardo lo Sviluppatore",
+    "mike_kasberg": "<0>Mike Kasberg</0> sviluppa ConfessLo nel suo tempo libero, per ridare qualcosa alla chiesa in cambio di tutto quello che ha ricevuto. È anche coinvolto in alcuni altri piccoli progetti per supportare le organizzazioni cattoliche con la tecnologia.",
+    "information": "Le citazioni bibliche di quest'app provengono dall'edizione CEI 2008 della Bibbia. Vengono tratte informazioni anche dal Catechismo della Chiesa Cattolica."
+  },
+  "help": {
+    "confessit_help": "ConfessaLo Assistenza",
+    "basic_usage": "Utilizzo di base",
+    "step_1": "Nella scheda <strong>Esamina</strong>, spunta <strong>Sì</strong> accanto ai peccati di cui vuoi fare una promemoria per la confessione.",
+    "step_2": "Scorri alla prossima scheda, <strong>Peccati</strong>, per vedere la lista dei peccati che hai segnato. Puoi anche revisionare ancora la lista prima o durante la confessione.",
+    "step_3": "Se non sei sicuro di cosa dire durante la confessione, scorri alla scheda successiva, <strong>Procedura dettagliata</strong>, dove puoi visionare per sommi capi il dialogo che avviene tra sacerdote e penitente durante la confessione. Puoi anche riguardarti questa sezione durante la confessione se ti è di aiuto.",
+    "step_4": "Una volta che ti sei confessato, puoi usare il pulsante <strong>Svuota</strong> per eliminare tutti i peccati segnati.",
+    "data_persistence": "Persistenza dei dati",
+    "data_persistence_text": "I dati inseriti sono memorizzati direttamente sul dispositivo (mai inviati su Internet). I dati inseriti rimangono fintanto che non premi il pulsante <strong>Svuota</strong>, e persistono anche se chiudi la finestra o aggiorni la pagina. Assicùrati pertanto di cancellare i dati quando hai finito, se non vuoi che altre persone che usano questo dispositivo vedano i tuoi dati!"
+  },
+  "welcome": {
+    "title": "Benvenuto!",
+    "body": " è uno strumento per assistere Cattolici romani nell'esame di coscienza prima di andare alla confessione. Speriamo che possa esserti d'aiuto nel fare mente locale dei peccati commessi dall'ultima confessione. Semplicemente puoi spuntare la casella <strong>Sì</strong> accanto ai peccati nell'elenco <strong>Esamina</strong>, oppure toccare il pulsante <kbd>+</kbd> in fondo a destra all'app per aggiungerne uno personalizzato. Poi, scorri verso destra alla scheda <strong>Revisiona</strong> per visualizzare l'elenco dei tuoi peccati, e poi di nuovo alla scheda <strong>Confessa</strong> per rivedere il rito della confessione. <br /><br />I dati da te immessi sono immagazzinati soltanto sul tuo dispositivo (<strong>mai</strong> verranno trasmessi via internet). I dati da te immessi permangono nell'app, anche se chiudi la finestra o ricarichi la pagina, fino a quando non scegli <strong>Svuota</strong> dalle impostazioni dell'app.<br /><br />Che il Signore ti benedica nel tuo cammino verso la santità!"
+  },
+  "commandments": {
+    "1": {
+      "title": "Primo Comandamento",
+      "text": "Non avrai altri dèi di fronte a me (Es 20,3)",
+      "description": "Io sono il Signore, tuo Dio, che ti ho fatto uscire dalla terra d'Egitto, dalla condizione servile: Non avrai altri dèi di fronte a me... Non ti prostrerai davanti a loro e non li servirai. Perché io, il Signore, tuo Dio, sono un Dio geloso... che dimostra la sua bontà fino a mille generazioni, per quelli che mi amano e osservano i miei comandamenti. (Es 20,2-6) I peccati capitali di orgoglio e ghiottoneria vanno contro questo comandamento."
     },
-    "examine_list": {
-        "examine": "Esamina"
+    "2": {
+      "title": "Secpndo Comandamento",
+      "text": "Non pronuncerai invano il nome del Signore, tuo Dio. (Es 20,7)",
+      "description": "Non pronuncerai invano il nome del Signore, tuo Dio, perché il Signore non lascia impunito chi pronuncia il suo nome invano. (Es 20,7)"
     },
-    "sins_list": {
-        "review": "Revisiona"
+    "3": {
+      "title": "Terzo Comandamento",
+      "text": "Ricòrdati del giorno del sabato per santificarlo. (Es 20,8)",
+      "description": "Ricòrdati del giorno del sabato per santificarlo. Sei giorni lavorerai e farai ogni tuo lavoro; ma il settimo giorno è il sabato in onore del Signore, tuo Dio: non farai alcun lavoro, né tu né tuo figlio né tua figlia, né il tuo schiavo né la tua schiava, né il tuo bestiame, né il forestiero che dimora presso di te. Perché in sei giorni il Signore ha fatto il cielo e la terra e il mare e quanto è in essi, ma si è riposato il settimo giorno. Perciò il Signore ha benedetto il giorno del sabato e lo ha consacrato. (Es 20,8-11)"
     },
-    "walkthrough": {
-        "walkthrough": "Confessa",
-        "in_the_name_of": "Nel nome del Padre, e del Figlio, e dello Spirito Santo. Amen.",
-        "bless_me_father": "Benedicimi Padre, perché ho peccato. Sono ____ dall'ultima confessione. Questi sono i miei peccati:",
-        "these_are_my_sins": "Questi sono i miei peccati, e me ne pento con tutto il cuore.",
-        "your_confessor_may_offer": "(Il confessore può ora offrire dei consigli o intrattenere una breve conversazione.)",
-        "your_confessor_will_assign": "(Il confessore ti assegnerà una penitenza da adempiere.) Ora recita l'atto di dolore.",
-        "act_of_contrition": "<p>Mio Dio, mi pento e mi dolgo con tutto il cuore dei miei peccati.</p><p>Perché peccando ho meritato i tuoi castighi, e molto più perché ho offeso te, infinitamente buono e degno di essere amato sopra ogni cosa.</p><p>Propongo con il tuo santo aiuto di non offenderti mai più, e di fuggire le occasioni prossime di peccato.</p><p>Signore, misericordia, perdonami.</p>",
-        "god_the_father_of_mercies": "Dio, Padre di misericordia…",
-        "amen": "Amen.",
-        "the_lord_has_freed_you": "Il Signore ha perdonato i tuoi peccati. Va' in pace.",
-        "thanks_be_to_god": "Lodiamo il Signore perché è buono."
+    "4": {
+      "title": "Quarto Comandamento",
+      "text": "Onora tuo padre e tua madre. (Es 20,12)",
+      "description": "Onora tuo padre e tua madre, perché si prolunghino i tuoi giorni nel paese che il Signore, tuo Dio, ti dà. (Es 20,12)"
     },
-    "prayers": {
-        "prayers": "Preghiere",
-        "prayer_before_confession": "Preghiera prima della Confessione",
-        "act_of_contrition": "Atto di Dolore",
-        "another_act_of_contrition": "Altro Atto di Dolore",
-        "thanksgiving_after_confession": "Ringraziamento dopo la Confessione",
-        "our_father": "Padre Nostro",
-        "hail_mary": "Ave Maria",
-        "hail_holy_queen": "Salve Regina",
-        "prayer_before_confession_text": "<p>Padre santo, come il figliol prodigo mi rivolgo alla tua misericordia:<br />«Ho peccato contro di te, non son più degno d'esser chiamato tuo figlio ».<br />Cristo Gesù, Salvatore del mondo, che hai aperto al buon ladrone le porte del paradiso, ricordati di me nel tuo regno.<br />Spirito Santo, sorgente di pace e d'amore, fa' che purificato da ogni colpa e riconciliato con il Padre io cammini sempre come figlio della luce.<br />Amen.</p>",
-        "act_of_contrition_text": "<p>Ricordati, Signore, del tuo amore,<br />della tua fedeltà che è da sempre.<br />Non ricordare i miei peccati:<br />ricordati di me nella tua misericordia,<br />per la tua bontà, Signore.</p>",
-        "another_act_of_contrition_text": "<p>Lavami, Signore, da tutte le mie colpe,<br />mondami dal mio peccato.<br />Riconosco la mia colpa,<br />il mio peccato mi sta sempre dinanzi.<br />Amen.</p>",
-        "thanksgiving_after_confession_text": "<p>Dio mio, Padre dolcissimo, com'è dolce la tua grazia, com'è grande il tuo amore! Hai perdonato tutti i miei peccati e mi hai fatto assaporare di nuovo le meraviglie del tuo amore. Ti ringraziano per me, o mio Dio, il Cielo e la terra ed io do voce a tutte le creature per lodarti e ringraziarti per sempre. Ti ringraziano le Anime del Purgatorio, per le quali ora Ti saranno più accette le mie preghiere, poiché ho l'anima purificata da ogni peccato e sono di nuovo tuo amico.<br />Per mostrarti la mia riconoscenza, o Signore, come meglio posso, Ti offro la promessa di voler evitare ad ogni costo il peccato.<br />Piuttosto, o mio Dio, scelgo il disprezzo del mondo, le mortificazioni e le pene, le tribolazioni di ogni tipo, ed anche la morte, ma mai più voglio trasgredire i tuoi precetti che sono consigli di Padre amorevole.<br />Per mezzo della santa assoluzione mi hai accolto ancora nel tuo abbraccio paterno, ed io non voglio più staccarmi da Te. <br />Amen.</p>",
-        "our_father_text": "<p>Padre nostro,<br />che sei nei cieli, sia santificato il Tuo nome;<br />venga il Tuo regno; sia fatta la Tua volontà, come in cielo così in terra.<br />Dàcci oggi il nostro pane quotidiano, e rimètti a noi i nostri debiti,<br />come anche noi li rimettiamo ai nostri debitori.<br />E non ci abbandonare alla tentazione, ma lìberaci dal male.<br />Amen.</p>",
-        "hail_mary_text": "<p>Ave Maria, piena di grazia.<br />Il Signore è con te.<br />Benedetta tu fra le donne, e benedtto il frutto del tuo seno, Gesù.<br />Santa Maria, madre di Dio,<br />prèga per noi peccatori, ora e nell'ora della nostra morte.<br />Amen.</p>",
-        "hail_holy_queen_text": "<p>Salve, Regina, madre di misericordia,<br />vita, dolcezza e speranza nostra, salve.<br />A te ricorriamo, esuli figli di Eva; a te sospiriamo, gementi e piangenti in questa valle di lacrime.<br />Orsù dunque, avvocata nostra, rivolgi a noi gli occhi tuoi misericordiosi.<br />E mostraci, dopo questo esilio, Gesù, il frutto benedetto del tuo Seno.<br />O clemente, o pia, o dolce Vergine Maria!</p>"
+    "5": {
+      "title": "Quinto Comandamento",
+      "text": "Non ucciderai. (Es 20,13)",
+      "description": "Non ucciderai. (Es 20,13). Il peccato capitale dell'ira è associato a questo comandamento."
     },
-    "about": {
-        "about_confessit": "Riguardo ConfessaLo",
-        "about_confessit_text": "ConfessIt è un esame di coscienza <vatican>Cattolico Romano</vatican> per computer, tablet, e smartphone. E' pensato per la facilità d'utilizzo, per essere di aiuto nel fare mente locale dei peccati da confessare. C'è anche una guida che ti segue passo passo nel rito della confessione, per aiutarti durante il rito. Una grande risorsa se non ti sei confessato da tempo! L'esame di coscienza si basa sugli insegnamenti della chiesa cattolica, è facile da comprendere, e risulta attuale per i cattolici di oggi.",
-        "about_confession": "Riguardo la Confessione",
-        "about_confession_intro": "La Confessione è il sacramento con il quale i Cattolici ottengono il perdono dei peccati dalla misericordia di Dio, e vengono così riconciliati con la Chiesa, la comunità dei credenti, il Corpo di Cristo.",
-        "ccc_quote": "<p>È chiamato sacramento della Conversione poiché realizza sacramentalmente l'appello di Gesù alla conversione,4 il cammino di ritorno al Padre (Cf Mc 1,15;Lc 15,18) da cui ci si è allontanati con il peccato.</p><p>È chiamato sacramento della Penitenza poiché consacra un cammino personale ed ecclesiale di conversione, di pentimento e di soddisfazione del cristiano peccatore.</p><p>È chiamato sacramento della Confessione poiché l'accusa, la confessione dei peccati davanti al sacerdote è un elemento essenziale di questo sacramento. In un senso profondo esso è anche una « confessione », riconoscimento e lode della santità di Dio e della sua misericordia verso l'uomo peccatore.</p><p>È chiamato sacramento del Perdono poiché, attraverso l'assoluzione sacramentale del sacerdote, Dio accorda al penitente « il perdono e la pace ». (Rito della Penitenza, 46. 55)</p><p>È chiamato sacramento della Riconciliazione perché dona al peccatore l'amore di Dio che riconcilia: « Lasciatevi riconciliare con Dio » (2 Cor 5,20). Colui che vive dell'amore misericordioso di Dio è pronto a rispondere all'invito del Signore: « Va' prima a riconciliarti con il tuo fratello » (Mt 5,24)</p><p>La conversione a Cristo, la nuova nascita dal Battesimo, il dono dello Spirito Santo, il Corpo e il Sangue di Cristo ricevuti in nutrimento, ci hanno resi « santi e immacolati al suo cospetto » (Ef 1,4), come la Chiesa stessa, Sposa di Cristo, è « santa e immacolata » (Ef 5,27) davanti a lui. Tuttavia, la vita nuova ricevuta nell'iniziazione cristiana non ha soppresso la fragilità e la debolezza della natura umana, né l'inclinazione al peccato che la tradizione chiama concupiscenza, la quale rimane nei battezzati perché sostengano le loro prove nel combattimento della vita cristiana, aiutati dalla grazia di Cristo. (Cf Concilio di Trento, Sess. 5a, Decretum de peccato originali, canone 5.) Si tratta del combattimento della conversione in vista della santità e della vita eterna alla quale il Signore non cessa di chiamarci.</p><p>Gesù chiama alla conversione. Questo appello è una componente essenziale dell'annuncio del Regno: « Il tempo è compiuto e il regno di Dio è ormai vicino; convertitevi e credete al Vangelo » (Mc 1,15). Il Battesimo è quindi il luogo principale della prima e fondamentale conversione, ma l'appello di Cristo alla conversione continua a risuonare nella vita dei cristiani. Questa seconda conversione è un impegno continuo per tutta la Chiesa che « comprende nel suo seno i peccatori » e che, « santa insieme e sempre bisognosa di purificazione, incessantemente si applica alla penitenza e al suo rinnovamento ». (Concilio Vaticano II, Cost. dogm. Lumen gentium, 8.) Questo sforzo di conversione non è soltanto un'opera umana. È il dinamismo del « cuore contrito » (Cf Sal 51,19) attirato e mosso dalla grazia (Cf Gv 6,44; 12,32) a rispondere all'amore misericordioso di Dio che ci ha amati per primo (Cf 1 Gv 4,10). A proposito delle due conversioni sant'Ambrogio dice: « La Chiesa ha l'acqua e le lacrime: l'acqua del Battesimo, le lacrime della Penitenza » (Sant'Ambrogio, Epistula extra collectionem, 1 [41], 12).</p><7>— Catechismo della Chiesa Cattolica 1423-1424,1426; cf. 1427-1429</7>",
-        "where_to_find": "Gli orari per la confessione sono elencati nel bollettino della tua parrocchia, o li puoi trovare sul sito della tua parrocchia oppure sul sito <mass>masstimes.org</mass>. Puoi anche prenotare una confessione rivolgendoti direttamente alla tua parrocchia.",
-        "about_confession_end": "Quando ti confessi, hai generalmente la scelta tra stare seduti a faccia a faccia con il confessore, o stare in ginocchio dietro una grata in maniera più anonima. Non c'è motivo per preoccuparsi nella confessione! Qualsiasi peccato potrai accusare, il sacerdote l'ha già ascoltato. Ricòrdati che il sacerdote è lì per te, per aiutarti, per il tuo bene.",
-        "about_this_app": "Riguardo quest'App",
-        "this_app_is_designed": "Quest'app è pensata per assistere i cattolici che desiderano confessarsi, nella fase dell'esame di coscienza prima della confessione. <strong>NON</strong> si tratta di un sostituto per la confessione.",
-        "please_be_respectful": "Si raccomanda avere un occhio di riguardo per coloro che possano stare nelle vicinanze quando fai uso dell'app. Si raccomanda di utilizzare l'app prima di giungere in chiesa, e di spegnere poi il telefono quando si è in chiesa. Se usi l'app dentro la chiesa o durante la confessione, assicùrati che il telefono sia in modalità silenziosa.",
-        "this_website": "Questo sito, <website>ConfessIt.app</website>, è basato sull'<app>App ConfessIt per Android</app> (creato nel 2012 dallo stesso sviluppatore). Mentre non è (ancora) una riproduzione completa, mira a rendere l'app maggiormente disponibile per più utenti su più dispositivi. (Questo sito funziona su iOS, Android, sia su tablet che su computer!)",
-        "if_you_find": "Se ti piace l'app, <strong>condivìdila</strong> con amici e parenti. Pàrlane su Facebook, Reddit, Twitter, in chiesa, o nel tuo gruppo di catechesi in modo da farla conoscere!",
-        "privacy": "Privacy",
-        "information_you_enter": "Le informazioni immesse nell'app sono immagazzinate soltanto sul tuo dispositivo. Non vengono trasmesse via internet. Questo è possibile grazie ad una tecnologia offerta dal browser, chiamata <a>local storage</a>. Non viene utilizzato alcun sistema di analisi dei dati, del tipo Google Analytics o qualsiasi altro sistema simile. I dati da te immessi permangono sul dispositivo anche se chiudi la finestra o aggiorni la pagina; vengono eliminati solo quando fai clic su <kbd>Svuota</kbd>.",
-        "open_source": "Sorgenti Aperte",
-        "confessit_is_open_source": "ConfessIt è un progetto informatico a sorgenti aperte (\"open source\"). Sviluppiamo l'app su <i></i> <github>GitHub</github> e collaboriamo nella comunità <osc>Open Source Catholic</osc> su Slack.",
-        "can_i_help_with_translations": "Posso aiutare con le traduzioni?",
-        "confessit_is_translated": "ConfessIt è tradotto in varie lingue. Se puoi aiutare in questo, aggiungendo una nuova traduzione o migliorando una traduzione già esistente, leggi su <github>GitHub</github> come fare per contribuire, oppure rivolgiti a noi nello spazio di lavoro <osc>Open Source Catholic</osc> su Slack.",
-        "can_i_help_write_code": "Posso aiutare a scrivere codice?",
-        "we_welcome_new_contributions": "Nuovi contributi sono benvenuti. Se vuoi contribuire allo sviluppo di ConfessaLo, inizia col leggere le istruzioni su <1>GitHub</1> per i contributi.",
-        "about_the_developer": "Riguardo lo Sviluppatore",
-        "mike_kasberg": "<0>Mike Kasberg</0> sviluppa ConfessLo nel suo tempo libero, per ridare qualcosa alla chiesa in cambio di tutto quello che ha ricevuto. È anche coinvolto in alcuni altri piccoli progetti per supportare le organizzazioni cattoliche con la tecnologia.",
-        "information": "Le citazioni bibliche di quest'app provengono dall'edizione CEI 2008 della Bibbia. Vengono tratte informazioni anche dal Catechismo della Chiesa Cattolica."
+    "6": {
+      "title": "Sesto Comandamento",
+      "text": "Non commetterai adulterio. (Es 20,14)",
+      "description": "Non commetterai adulterio. (Es 20,14) Il peccato capitale della lussuria va contro questo comandamento."
     },
-    "help": {
-        "confessit_help": "ConfessaLo Assistenza",
-        "basic_usage": "Utilizzo di base",
-        "step_1": "Nella scheda <strong>Esamina</strong>, spunta <strong>Sì</strong> accanto ai peccati di cui vuoi fare una promemoria per la confessione.",
-        "step_2": "Scorri alla prossima scheda, <strong>Peccati</strong>, per vedere la lista dei peccati che hai segnato. Puoi anche revisionare ancora la lista prima o durante la confessione.",
-        "step_3": "Se non sei sicuro di cosa dire durante la confessione, scorri alla scheda successiva, <strong>Procedura dettagliata</strong>, dove puoi visionare per sommi capi il dialogo che avviene tra sacerdote e penitente durante la confessione. Puoi anche riguardarti questa sezione durante la confessione se ti è di aiuto.",
-        "step_4": "Una volta che ti sei confessato, puoi usare il pulsante <strong>Svuota</strong> per eliminare tutti i peccati segnati.",
-        "data_persistence": "Persistenza dei dati",
-        "data_persistence_text": "I dati inseriti sono memorizzati direttamente sul dispositivo (mai inviati su Internet). I dati inseriti rimangono fintanto che non premi il pulsante <strong>Svuota</strong>, e persistono anche se chiudi la finestra o aggiorni la pagina. Assicùrati pertanto di cancellare i dati quando hai finito, se non vuoi che altre persone che usano questo dispositivo vedano i tuoi dati!"
+    "7": {
+      "title": "Settimo Comandamento",
+      "text": "Non ruberai. (Es 20,15)",
+      "description": "Non ruberai. (Es 20,15) I peccati capitali dell'invidia e dell'ignavia vanno contro questo comandamento."
     },
-    "welcome": {
-        "title": "Benvenuto!",
-        "body": " è uno strumento per assistere Cattolici romani nell'esame di coscienza prima di andare alla confessione. Speriamo che possa esserti d'aiuto nel fare mente locale dei peccati commessi dall'ultima confessione. Semplicemente puoi spuntare la casella <strong>Sì</strong> accanto ai peccati nell'elenco <strong>Esamina</strong>, oppure toccare il pulsante <kbd>+</kbd> in fondo a destra all'app per aggiungerne uno personalizzato. Poi, scorri verso destra alla scheda <strong>Revisiona</strong> per visualizzare l'elenco dei tuoi peccati, e poi di nuovo alla scheda <strong>Confessa</strong> per rivedere il rito della confessione. <br /><br />I dati da te immessi sono immagazzinati soltanto sul tuo dispositivo (<strong>mai</strong> verranno trasmessi via internet). I dati da te immessi permangono nell'app, anche se chiudi la finestra o ricarichi la pagina, fino a quando non scegli <strong>Svuota</strong> dalle impostazioni dell'app.<br /><br />Che il Signore ti benedica nel tuo cammino verso la santità!"
+    "8": {
+      "title": "Ottavo Comandamento",
+      "text": "Non pronuncerai falsa testimonianza contro il tuo prossimo. (Es 20,16)",
+      "description": "Non pronuncerai falsa testimonianza contro il tuo prossimo. (Es 20,16)"
     },
-    "commandments": {
-        "1": {
-            "title": "Primo Comandamento",
-            "text": "Non avrai altri dèi di fronte a me (Es 20,3)",
-            "description": "Io sono il Signore, tuo Dio, che ti ho fatto uscire dalla terra d'Egitto, dalla condizione servile: Non avrai altri dèi di fronte a me... Non ti prostrerai davanti a loro e non li servirai. Perché io, il Signore, tuo Dio, sono un Dio geloso... che dimostra la sua bontà fino a mille generazioni, per quelli che mi amano e osservano i miei comandamenti. (Es 20,2-6) I peccati capitali di orgoglio e ghiottoneria vanno contro questo comandamento."
-        },
-        "2": {
-            "title": "Secpndo Comandamento",
-            "text": "Non pronuncerai invano il nome del Signore, tuo Dio. (Es 20,7)",
-            "description": "Non pronuncerai invano il nome del Signore, tuo Dio, perché il Signore non lascia impunito chi pronuncia il suo nome invano. (Es 20,7)"
-        },
-        "3": {
-            "title": "Terzo Comandamento",
-            "text": "Ricòrdati del giorno del sabato per santificarlo. (Es 20,8)",
-            "description": "Ricòrdati del giorno del sabato per santificarlo. Sei giorni lavorerai e farai ogni tuo lavoro; ma il settimo giorno è il sabato in onore del Signore, tuo Dio: non farai alcun lavoro, né tu né tuo figlio né tua figlia, né il tuo schiavo né la tua schiava, né il tuo bestiame, né il forestiero che dimora presso di te. Perché in sei giorni il Signore ha fatto il cielo e la terra e il mare e quanto è in essi, ma si è riposato il settimo giorno. Perciò il Signore ha benedetto il giorno del sabato e lo ha consacrato. (Es 20,8-11)"
-        },
-        "4": {
-            "title": "Quarto Comandamento",
-            "text": "Onora tuo padre e tua madre. (Es 20,12)",
-            "description": "Onora tuo padre e tua madre, perché si prolunghino i tuoi giorni nel paese che il Signore, tuo Dio, ti dà. (Es 20,12)"
-        },
-        "5": {
-            "title": "Quinto Comandamento",
-            "text": "Non ucciderai. (Es 20,13)",
-            "description": "Non ucciderai. (Es 20,13). Il peccato capitale dell'ira è associato a questo comandamento."
-        },
-        "6": {
-            "title": "Sesto Comandamento",
-            "text": "Non commetterai adulterio. (Es 20,14)",
-            "description": "Non commetterai adulterio. (Es 20,14) Il peccato capitale della lussuria va contro questo comandamento."
-        },
-        "7": {
-            "title": "Settimo Comandamento",
-            "text": "Non ruberai. (Es 20,15)",
-            "description": "Non ruberai. (Es 20,15) I peccati capitali dell'invidia e dell'ignavia vanno contro questo comandamento."
-        },
-        "8": {
-            "title": "Ottavo Comandamento",
-            "text": "Non pronuncerai falsa testimonianza contro il tuo prossimo. (Es 20,16)",
-            "description": "Non pronuncerai falsa testimonianza contro il tuo prossimo. (Es 20,16)"
-        },
-        "9": {
-            "title": "Nono Comandamento",
-            "text": "Non desidererai la moglie del tuo prossimo. (Es 20,17)",
-            "description": "Non desidererai la moglie del tuo prossimo. (Es 20,17) Il peccato capitale della gelosia va contro questo comandamento."
-        },
-        "10": {
-            "title": "Decimo Comandamento",
-            "text": "Non desidererai la casa del tuo prossimo... né alcuna cosa che appartenga al tuo prossimo. (Es 20,17)",
-            "description": "Non desidererai la casa del tuo prossimo. Non desidererai la moglie del tuo prossimo, né il suo schiavo né la sua schiava, né il suo bue né il suo asino, né alcuna cosa che appartenga al tuo prossimo. (Es 20,17) Il peccato capitale della gelosia va contro questo comandamento."
-        },
-        "11": {
-            "title": "Precetti della Chiesa",
-            "text": "I precetti della Chiesa Cattolica sono gli adempimenti minimi richiesti da ogni Cattolico.",
-            "description": "I precetti della Chiesa si collocano in questa linea di una vita morale che si aggancia alla vita liturgica e di essa si nutre. Il carattere obbligatorio di tali leggi positive promulgate dalle autorità pastorali, ha come fine di garantire ai fedeli il minimo indispensabile nello spirito di preghiera e nell'impegno morale, nella crescita del l'amore di Dio e del prossimo (CCC 2041)."
-        }
+    "9": {
+      "title": "Nono Comandamento",
+      "text": "Non desidererai la moglie del tuo prossimo. (Es 20,17)",
+      "description": "Non desidererai la moglie del tuo prossimo. (Es 20,17) Il peccato capitale della gelosia va contro questo comandamento."
     },
-    "sins": {
-        "1": {
-            "text": "Ho rifiutato qualche insegnamento della Chiesa Cattolica?",
-            "text_past": "Ho rifiutato gli insegnamenti della Chiesa Cattolica.",
-            "detail": "Obbedire nella fede è sottomettersi liberamente alla parola ascoltata, perché la sua verità è garantita da Dio, il quale è la verità stessa (CCC 144). Credere agli insegnamenti della chiesa è la via della salvezza."
-        },
-        "2": {
-            "text": "Ho praticato altre religioni che non siano il Cattolicesimo?",
-            "text_past": "Ho praticato altre religioni che siano il Cattolicesimo.",
-            "detail": "Il primo comandamento vieta di onorare altri dèi, all'infuori dell'unico Signore che si è rivelato al suo popolo. Proibisce la superstizione e l'irreligione. La superstizione rappresenta, in qualche modo, un eccesso perverso della religione; l'irreligione è un vizio opposto, per difetto, alla virtù della religione."
-        },
-        "3": {
-            "text": "Ho peccato di presunzione, dando per scontato la misericordia di Dio e quindi acconsentendo al peccato senza scrupolo?",
-            "text_past": "Ho peccato di presunzione nei confronti della misericordia divina.",
-            "detail": "Ci sono due tipi di presunzione. O l'uomo presume delle proprie capacità (sperando di potersi salvare senza l'aiuto dall'alto), oppure presume della onnipotenza e della misericordia di Dio (sperando di ottenere il suo perdono senza conversione e la gloria senza merito) (CCC 2092). E' illecito compiere un atto immorale nella previsione che Dio sarà misericordioso."
-        },
-        "4": {
-            "text": "Com'è la mia vita di preghiera? Dovrei forse pregare di più?",
-            "text_past": "Dovrei pregare di più.",
-            "detail": "Adorare Dio, pregarlo, rendergli il culto che a lui è dovuto, mantenere le promesse e i voti che a lui si sono fatti, sono atti della virtù della religione, che esprimono l'obbedienza al primo comandamento (CC 2135). Senza la preghiera non possiamo avere un vero rapporto con Dio."
-        },
-        "5": {
-            "text": "Il mondo talvolta va in conflitto con gli ideali Cattolici. Sono venuto meno nell'adesione ai valori morali Cattolici?",
-            "text_past": "Sono venuto meno nell'adesione ai valori morali Cattolici.",
-            "detail": ""
-        },
-        "6": {
-            "text": "Ho usato un linguaggio volgare?",
-            "text_past": "Ho usato un linguaggio volgare.",
-            "detail": ""
-        },
-        "7": {
-            "text": "Ho usato il nome di Dio invano?",
-            "text_past": "Ho usato il nome di Dio invano.",
-            "detail": "Il secondo comandamento proibisce ogni uso sconveniente del nome di Dio. La bestemmia consiste nell'usare il nome di Dio, di Gesù Cristo, della Vergine Maria e dei santi in un modo ingiurioso (CC 2162)."
-        },
-        "8": {
-            "text": "Ho insultato Dio?",
-            "text_past": "Ho insultato Dio.",
-            "detail": "Il rispetto per il nome di Dio esprime quello dovuto al suo stesso mistero e a tutta la realtà sacra da esso evocata (CC 2144)."
-        },
-        "9": {
-            "text": "Ho saltato la Messa domenicale?",
-            "text_past": "Ho saltato la Messa domenicale.",
-            "detail": "Il primo precetto (« Partecipa alla Messa la domenica e le altre feste comandate e rimani libero dalle occupazioni del lavoro ») esige dai fedeli che santifichino il giorno in cui si ricorda la risurrezione del Signore e le particolari festività liturgiche in onore dei misteri del Signore, della beata Vergine Maria e dei santi, in primo luogo partecipando alla celebrazione eucaristica in cui si riunisce la comunità cristiana, e che riposino da quei lavori e da quelle attività che potrebbero impedire una tale santificazione di questi giorni (CC2042). Da Cattolici, attendiamo con gioia la celebrazione Eucaristica domenicale. E' un peccato saltare la Messa, perché in questa maniera il nostro rapporto con Dio si indebolisce."
-        },
-        "10": {
-            "text": "Ho saltato la Messa nei giorni di precetto?",
-            "text_past": "Ho saltato la Messa nei giorni di precetto.",
-            "detail": ""
-        },
-        "11": {
-            "text": "Sono arrivato tardi a Messa o sono andato via prima?",
-            "text_past": "Sono arrivato tardi a Messa o sono andato via prima.",
-            "detail": "Affrettarsi verso la chiesa, avvicinarsi al Signore e confessare i propri peccati, pentirsi durante la preghiera… Assistere alla santa e divina liturgia, terminare la propria preghiera e non uscirne prima del congedo… (CCC 2178). Arrivare in ritardo o andare via prima è anche irrispettoso nei confronti di altri che sono raccolti in preghiera, e crea distrazione."
-        },
-        "12": {
-            "text": "Ho disobbedito ai genitori?",
-            "text_past": "Ho disobbedito ai genitori.",
-            "detail": ""
-        },
-        "13": {
-            "text": "Ho mancato nell'impartire / testimoniare la fede Cattolica ai miei figli?",
-            "text_past": "Ho mancato nell'impartire / testimoniare la fede Cattolica ai miei figli.",
-            "detail": ""
-        },
-        "14": {
-            "text": "Ho mancato di prendermi cura dei miei parenti più anziani?",
-            "text_past": "Ho mancato di prendermi cura dei miei parenti più anziani.",
-            "detail": ""
-        },
-        "15": {
-            "text": "Ho trascurato la mia famiglia?",
-            "text_past": "Ho trascurato la mia famiglia.",
-            "detail": ""
-        },
-        "16": {
-            "text": "Ho disobbedito ad un adulto responsabile?",
-            "text_past": "Ho disobbedito ad un adulto responsabile.",
-            "detail": ""
-        },
-        "17": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "18": {
-            "text": "Ho infranto una legge giusta?",
-            "text_past": "Ho infranto una legge giusta.",
-            "detail": ""
-        },
-        "19": {
-            "text": "Ho recato un danno fisico a qualcuno?",
-            "text_past": "Ho recato un danno fisico a qualcuno.",
-            "detail": ""
-        },
-        "20": {
-            "text": "Ho procurato un aborto? Oppure ho partecipato a procurare un aborto?",
-            "text_past": "Ho procurato o ho partecipato in un aborto.",
-            "detail": ""
-        },
-        "21": {
-            "text": "Ho usato contraccettivi?",
-            "text_past": "Ho usato contraccettivi.",
-            "detail": "\"È intrinsecamente cattiva ogni azione che, o in previsione dell'atto coniugale, o nel suo compimento, o nello sviluppo delle sue conseguenze naturali, si proponga, come scopo o come mezzo, di impedire la procreazione\" (CCC 2370). \"La legittimità delle intenzioni degli sposi non giustifica il ricorso a mezzi moralmente inaccettabili (per esempio, la sterilizzazione diretta o la contraccezione)\" (CCC 2399). La contraccezione artificiale è moralmente errata perché trasforma quello che dovrebbe essere un atto di amore in un atto di egoismo."
-        },
-        "22": {
-            "text": "Ho tentato il suicidio?",
-            "text_past": "Ho tentato il suicidio.",
-            "detail": ""
-        },
-        "23": {
-            "text": "Ho partecipato nell'eutanasia?",
-            "text_past": "Ho partecipato nell'eutanasia.",
-            "detail": ""
-        },
-        "24": {
-            "text": "Ho abusato di droga o alcol?",
-            "text_past": "Ho abusato di droga o alcol.",
-            "detail": ""
-        },
-        "25": {
-            "text": "Ho avuto rapporti intimi fuori del matrimonio?",
-            "text_past": "Ho avuto rapporti intimi fuori del matrimonio.",
-            "detail": ""
-        },
-        "26": {
-            "text": "Sono colpevole del peccato della lussuria?",
-            "text_past": "Sono colpevole del peccato di lussuria.",
-            "detail": ""
-        },
-        "27": {
-            "text": "Ho guardato alla pornografia?",
-            "text_past": "Ho guardato alla pornografia.",
-            "detail": ""
-        },
-        "28": {
-            "text": "Ho acconsentito a desideri contrari alla natura?",
-            "text_past": "Ho acconsentito a desideri contrari alla natura.",
-            "detail": ""
-        },
-        "29": {
-            "text": "Sono venuto meno nell'onorare mio marito / mia moglie?",
-            "text_past": "Sono venuto meno nell'onorare mio marito / mia moglie.",
-            "detail": ""
-        },
-        "30": {
-            "text": "Ho letto letteratura erotica?",
-            "text_past": "Ho letto letteratura erotica.",
-            "detail": ""
-        },
-        "31": {
-            "text": "Ho partecipato in atti sessuali immorali?",
-            "text_past": "Ho partecipato in atti sessuali immorali.",
-            "detail": ""
-        },
-        "32": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "33": {
-            "text": "Ho rubato? Se sì, con quale valore?",
-            "text_past": "Ho rubato, per un valore di ___.",
-            "detail": ""
-        },
-        "34": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "35": {
-            "text": "Sono stato menzognero/a o ingannevole?",
-            "text_past": "Sono stato menzognero o ingannevole.",
-            "detail": ""
-        },
-        "36": {
-            "text": "Mi sono dato al chiacchiericcio?",
-            "text_past": "Mi sono dato al chiacchiericcio.",
-            "detail": ""
-        },
-        "37": {
-            "text": "Ho mancato di osservare il digiuno il Mercoledì delle Ceneri ed il Venerdì Santo?",
-            "text_past": "Ho mancato di osservare il digiuno il Mercoledì delle Ceneri o il Venerdì Santo.",
-            "detail": ""
-        },
-        "38": {
-            "text": "Ho mancato di osservare l'astinenza dalla carne nei venerdì di quaresima e il Mercoledì delle Ceneri?",
-            "text_past": "Ho mancato di osservare l'astinenza dalla carne durante un venerdì di quaresima o il Mercoledì delle Ceneri.",
-            "detail": ""
-        },
-        "39": {
-            "text": "Ho mancato di ricevere l'Eucaristia almeno una volta durante il periodo pasquale?",
-            "text_past": "Ho mancato di ricevere l'Eucaristia almeno una volta durante la Pasqua.",
-            "detail": ""
-        },
-        "40": {
-            "text": "Ho mancato di osservare un'ora di digiuno prima di ricevere l'Eucaristia?",
-            "text_past": "Ho mancato di osservare un'ora di digiuno prima di ricevere l'Eucaristia.",
-            "detail": ""
-        },
-        "41": {
-            "text": "Ho ricevuto l'Eucaristia nello stato di peccato mortale?",
-            "text_past": "Ho ricevuto l'Eucaristia nello stato di peccato mortale.",
-            "detail": ""
-        },
-        "42": {
-            "text": "Ho nascosto intenzionalmente qualche peccato durante la confessione?",
-            "text_past": "Ho nascosto intenzionalmente qualche peccato durante la confessione.",
-            "detail": ""
-        },
-        "43": {
-            "text": "Ho mancato di curare il riposo domenicale, o il tempo dedicato alla famiglia?",
-            "text_past": "Ho mancato di curare il riposo domenicale, o il tempo dedicato alla famiglia.",
-            "detail": ""
-        },
-        "44": {
-            "text": "Ho desiderato la moglie/il marito oppure la fidanzata/il fidanzato di altri?",
-            "text_past": "Ho desiderato la moglie/il marito o la fidanzata/il fidanzato di altri.",
-            "detail": ""
-        },
-        "45": {
-            "text": "Ho desiderato i beni altrui?",
-            "text_past": "Ho desiderato i beni altrui.",
-            "detail": ""
-        },
-        "46": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "47": {
-            "text": "Ho ascoltato musica, oppure guardato un programma televisivo o un film, oppure ho letto letteratura che mi può influenzare negativamente?",
-            "text_past": "Ho ascoltato musica, oppure guardato un programma televisivo o un film, oppure ho letto letteratura che mi può influenzare negativamente.",
-            "detail": ""
-        },
-        "48": {
-            "text": "Sono stato/a avido/a, oppure ho mancato di donare con cuore generoso alla comunità ecclesiale e ai poveri?",
-            "text_past": "Sono stato/a avido/a oppure ho mancato di donare con cuore generoso alla comunità ecclesiale o ai poveri.",
-            "detail": ""
-        },
-        "49": {
-            "text": "Ho indotto consapevolmente altri al peccato?",
-            "text_past": "Ho indotto consapevolmente altri al peccato.",
-            "detail": ""
-        },
-        "50": {
-            "text": "Ho mancato di fare di Dio una priorità nella mia vita?",
-            "text_past": "Ho mancato di fare di Dio una priorità nella mia vita.",
-            "detail": ""
-        },
-        "51": {
-            "text": "Ho agito in maniera egoista?",
-            "text_past": "Ho agito in maniera egoista.",
-            "detail": ""
-        },
-        "52": {
-            "text": "Ho partecipato in pratiche occulte?",
-            "text_past": "Ho partecipato in pratiche occulte.",
-            "detail": ""
-        },
-        "53": {
-            "text": "Ho peccato di accidia al lavoro o a casa?",
-            "text_past": "Ho peccato di accidia al lavoro o a casa.",
-            "detail": ""
-        },
-        "54": {
-            "text": "",
-            "text_past": "",
-            "detail": ""
-        },
-        "55": {
-            "text": "Sono stato vanitoso o orgoglioso?",
-            "text_past": "Sono stato vanitoso o orgoglioso.",
-            "detail": ""
-        },
-        "56": {
-            "text": "Ho peccato di golosità?",
-            "text_past": "Ho peccato di golosità.",
-            "detail": ""
-        },
-        "57": {
-            "text": "Sono stato iracondo?",
-            "text_past": "Sono stato iracondo.",
-            "detail": ""
-        }
+    "10": {
+      "title": "Decimo Comandamento",
+      "text": "Non desidererai la casa del tuo prossimo... né alcuna cosa che appartenga al tuo prossimo. (Es 20,17)",
+      "description": "Non desidererai la casa del tuo prossimo. Non desidererai la moglie del tuo prossimo, né il suo schiavo né la sua schiava, né il suo bue né il suo asino, né alcuna cosa che appartenga al tuo prossimo. (Es 20,17) Il peccato capitale della gelosia va contro questo comandamento."
+    },
+    "11": {
+      "title": "Precetti della Chiesa",
+      "text": "I precetti della Chiesa Cattolica sono gli adempimenti minimi richiesti da ogni Cattolico.",
+      "description": "I precetti della Chiesa si collocano in questa linea di una vita morale che si aggancia alla vita liturgica e di essa si nutre. Il carattere obbligatorio di tali leggi positive promulgate dalle autorità pastorali, ha come fine di garantire ai fedeli il minimo indispensabile nello spirito di preghiera e nell'impegno morale, nella crescita del l'amore di Dio e del prossimo (CCC 2041)."
     }
+  },
+  "sins": {
+    "1": {
+      "text": "Ho rifiutato qualche insegnamento della Chiesa Cattolica?",
+      "text_past": "Ho rifiutato gli insegnamenti della Chiesa Cattolica.",
+      "detail": "Obbedire nella fede è sottomettersi liberamente alla parola ascoltata, perché la sua verità è garantita da Dio, il quale è la verità stessa (CCC 144). Credere agli insegnamenti della chiesa è la via della salvezza."
+    },
+    "2": {
+      "text": "Ho praticato altre religioni che non siano il Cattolicesimo?",
+      "text_past": "Ho praticato altre religioni che siano il Cattolicesimo.",
+      "detail": "Il primo comandamento vieta di onorare altri dèi, all'infuori dell'unico Signore che si è rivelato al suo popolo. Proibisce la superstizione e l'irreligione. La superstizione rappresenta, in qualche modo, un eccesso perverso della religione; l'irreligione è un vizio opposto, per difetto, alla virtù della religione."
+    },
+    "3": {
+      "text": "Ho peccato di presunzione, dando per scontato la misericordia di Dio e quindi acconsentendo al peccato senza scrupolo?",
+      "text_past": "Ho peccato di presunzione nei confronti della misericordia divina.",
+      "detail": "Ci sono due tipi di presunzione. O l'uomo presume delle proprie capacità (sperando di potersi salvare senza l'aiuto dall'alto), oppure presume della onnipotenza e della misericordia di Dio (sperando di ottenere il suo perdono senza conversione e la gloria senza merito) (CCC 2092). E' illecito compiere un atto immorale nella previsione che Dio sarà misericordioso."
+    },
+    "4": {
+      "text": "Com'è la mia vita di preghiera? Dovrei forse pregare di più?",
+      "text_past": "Dovrei pregare di più.",
+      "detail": "Adorare Dio, pregarlo, rendergli il culto che a lui è dovuto, mantenere le promesse e i voti che a lui si sono fatti, sono atti della virtù della religione, che esprimono l'obbedienza al primo comandamento (CC 2135). Senza la preghiera non possiamo avere un vero rapporto con Dio."
+    },
+    "5": {
+      "text": "Il mondo talvolta va in conflitto con gli ideali Cattolici. Sono venuto meno nell'adesione ai valori morali Cattolici?",
+      "text_past": "Sono venuto meno nell'adesione ai valori morali Cattolici.",
+      "detail": ""
+    },
+    "6": {
+      "text": "Ho usato un linguaggio volgare?",
+      "text_past": "Ho usato un linguaggio volgare.",
+      "detail": ""
+    },
+    "7": {
+      "text": "Ho usato il nome di Dio invano?",
+      "text_past": "Ho usato il nome di Dio invano.",
+      "detail": "Il secondo comandamento proibisce ogni uso sconveniente del nome di Dio. La bestemmia consiste nell'usare il nome di Dio, di Gesù Cristo, della Vergine Maria e dei santi in un modo ingiurioso (CC 2162)."
+    },
+    "8": {
+      "text": "Ho insultato Dio?",
+      "text_past": "Ho insultato Dio.",
+      "detail": "Il rispetto per il nome di Dio esprime quello dovuto al suo stesso mistero e a tutta la realtà sacra da esso evocata (CC 2144)."
+    },
+    "9": {
+      "text": "Ho saltato la Messa domenicale?",
+      "text_past": "Ho saltato la Messa domenicale.",
+      "detail": "Il primo precetto (« Partecipa alla Messa la domenica e le altre feste comandate e rimani libero dalle occupazioni del lavoro ») esige dai fedeli che santifichino il giorno in cui si ricorda la risurrezione del Signore e le particolari festività liturgiche in onore dei misteri del Signore, della beata Vergine Maria e dei santi, in primo luogo partecipando alla celebrazione eucaristica in cui si riunisce la comunità cristiana, e che riposino da quei lavori e da quelle attività che potrebbero impedire una tale santificazione di questi giorni (CC2042). Da Cattolici, attendiamo con gioia la celebrazione Eucaristica domenicale. E' un peccato saltare la Messa, perché in questa maniera il nostro rapporto con Dio si indebolisce."
+    },
+    "10": {
+      "text": "Ho saltato la Messa nei giorni di precetto?",
+      "text_past": "Ho saltato la Messa nei giorni di precetto.",
+      "detail": ""
+    },
+    "11": {
+      "text": "Sono arrivato tardi a Messa o sono andato via prima?",
+      "text_past": "Sono arrivato tardi a Messa o sono andato via prima.",
+      "detail": "Affrettarsi verso la chiesa, avvicinarsi al Signore e confessare i propri peccati, pentirsi durante la preghiera… Assistere alla santa e divina liturgia, terminare la propria preghiera e non uscirne prima del congedo… (CCC 2178). Arrivare in ritardo o andare via prima è anche irrispettoso nei confronti di altri che sono raccolti in preghiera, e crea distrazione."
+    },
+    "12": {
+      "text": "Ho disobbedito ai genitori?",
+      "text_past": "Ho disobbedito ai genitori.",
+      "detail": ""
+    },
+    "13": {
+      "text": "Ho mancato nell'impartire / testimoniare la fede Cattolica ai miei figli?",
+      "text_past": "Ho mancato nell'impartire / testimoniare la fede Cattolica ai miei figli.",
+      "detail": ""
+    },
+    "14": {
+      "text": "Ho mancato di prendermi cura dei miei parenti più anziani?",
+      "text_past": "Ho mancato di prendermi cura dei miei parenti più anziani.",
+      "detail": ""
+    },
+    "15": {
+      "text": "Ho trascurato la mia famiglia?",
+      "text_past": "Ho trascurato la mia famiglia.",
+      "detail": ""
+    },
+    "16": {
+      "text": "Ho disobbedito ad un adulto responsabile?",
+      "text_past": "Ho disobbedito ad un adulto responsabile.",
+      "detail": ""
+    },
+    "17": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "18": {
+      "text": "Ho infranto una legge giusta?",
+      "text_past": "Ho infranto una legge giusta.",
+      "detail": ""
+    },
+    "19": {
+      "text": "Ho recato un danno fisico a qualcuno?",
+      "text_past": "Ho recato un danno fisico a qualcuno.",
+      "detail": ""
+    },
+    "20": {
+      "text": "Ho procurato un aborto? Oppure ho partecipato a procurare un aborto?",
+      "text_past": "Ho procurato o ho partecipato in un aborto.",
+      "detail": ""
+    },
+    "21": {
+      "text": "Ho usato contraccettivi?",
+      "text_past": "Ho usato contraccettivi.",
+      "detail": "\"È intrinsecamente cattiva ogni azione che, o in previsione dell'atto coniugale, o nel suo compimento, o nello sviluppo delle sue conseguenze naturali, si proponga, come scopo o come mezzo, di impedire la procreazione\" (CCC 2370). \"La legittimità delle intenzioni degli sposi non giustifica il ricorso a mezzi moralmente inaccettabili (per esempio, la sterilizzazione diretta o la contraccezione)\" (CCC 2399). La contraccezione artificiale è moralmente errata perché trasforma quello che dovrebbe essere un atto di amore in un atto di egoismo."
+    },
+    "22": {
+      "text": "Ho tentato il suicidio?",
+      "text_past": "Ho tentato il suicidio.",
+      "detail": ""
+    },
+    "23": {
+      "text": "Ho partecipato nell'eutanasia?",
+      "text_past": "Ho partecipato nell'eutanasia.",
+      "detail": ""
+    },
+    "24": {
+      "text": "Ho abusato di droga o alcol?",
+      "text_past": "Ho abusato di droga o alcol.",
+      "detail": ""
+    },
+    "25": {
+      "text": "Ho avuto rapporti intimi fuori del matrimonio?",
+      "text_past": "Ho avuto rapporti intimi fuori del matrimonio.",
+      "detail": ""
+    },
+    "26": {
+      "text": "Sono colpevole del peccato della lussuria?",
+      "text_past": "Sono colpevole del peccato di lussuria.",
+      "detail": ""
+    },
+    "27": {
+      "text": "Ho guardato alla pornografia?",
+      "text_past": "Ho guardato alla pornografia.",
+      "detail": ""
+    },
+    "28": {
+      "text": "Ho acconsentito a desideri contrari alla natura?",
+      "text_past": "Ho acconsentito a desideri contrari alla natura.",
+      "detail": ""
+    },
+    "29": {
+      "text": "Sono venuto meno nell'onorare mio marito / mia moglie?",
+      "text_past": "Sono venuto meno nell'onorare mio marito / mia moglie.",
+      "detail": ""
+    },
+    "30": {
+      "text": "Ho letto letteratura erotica?",
+      "text_past": "Ho letto letteratura erotica.",
+      "detail": ""
+    },
+    "31": {
+      "text": "Ho partecipato in atti sessuali immorali?",
+      "text_past": "Ho partecipato in atti sessuali immorali.",
+      "detail": ""
+    },
+    "32": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "33": {
+      "text": "Ho rubato? Se sì, con quale valore?",
+      "text_past": "Ho rubato, per un valore di ___.",
+      "detail": ""
+    },
+    "34": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "35": {
+      "text": "Sono stato menzognero/a o ingannevole?",
+      "text_past": "Sono stato menzognero o ingannevole.",
+      "detail": ""
+    },
+    "36": {
+      "text": "Mi sono dato al chiacchiericcio?",
+      "text_past": "Mi sono dato al chiacchiericcio.",
+      "detail": ""
+    },
+    "37": {
+      "text": "Ho mancato di osservare il digiuno il Mercoledì delle Ceneri ed il Venerdì Santo?",
+      "text_past": "Ho mancato di osservare il digiuno il Mercoledì delle Ceneri o il Venerdì Santo.",
+      "detail": ""
+    },
+    "38": {
+      "text": "Ho mancato di osservare l'astinenza dalla carne nei venerdì di quaresima e il Mercoledì delle Ceneri?",
+      "text_past": "Ho mancato di osservare l'astinenza dalla carne durante un venerdì di quaresima o il Mercoledì delle Ceneri.",
+      "detail": ""
+    },
+    "39": {
+      "text": "Ho mancato di ricevere l'Eucaristia almeno una volta durante il periodo pasquale?",
+      "text_past": "Ho mancato di ricevere l'Eucaristia almeno una volta durante la Pasqua.",
+      "detail": ""
+    },
+    "40": {
+      "text": "Ho mancato di osservare un'ora di digiuno prima di ricevere l'Eucaristia?",
+      "text_past": "Ho mancato di osservare un'ora di digiuno prima di ricevere l'Eucaristia.",
+      "detail": ""
+    },
+    "41": {
+      "text": "Ho ricevuto l'Eucaristia nello stato di peccato mortale?",
+      "text_past": "Ho ricevuto l'Eucaristia nello stato di peccato mortale.",
+      "detail": ""
+    },
+    "42": {
+      "text": "Ho nascosto intenzionalmente qualche peccato durante la confessione?",
+      "text_past": "Ho nascosto intenzionalmente qualche peccato durante la confessione.",
+      "detail": ""
+    },
+    "43": {
+      "text": "Ho mancato di curare il riposo domenicale, o il tempo dedicato alla famiglia?",
+      "text_past": "Ho mancato di curare il riposo domenicale, o il tempo dedicato alla famiglia.",
+      "detail": ""
+    },
+    "44": {
+      "text": "Ho desiderato la moglie/il marito oppure la fidanzata/il fidanzato di altri?",
+      "text_past": "Ho desiderato la moglie/il marito o la fidanzata/il fidanzato di altri.",
+      "detail": ""
+    },
+    "45": {
+      "text": "Ho desiderato i beni altrui?",
+      "text_past": "Ho desiderato i beni altrui.",
+      "detail": ""
+    },
+    "46": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "47": {
+      "text": "Ho ascoltato musica, oppure guardato un programma televisivo o un film, oppure ho letto letteratura che mi può influenzare negativamente?",
+      "text_past": "Ho ascoltato musica, oppure guardato un programma televisivo o un film, oppure ho letto letteratura che mi può influenzare negativamente.",
+      "detail": ""
+    },
+    "48": {
+      "text": "Sono stato/a avido/a, oppure ho mancato di donare con cuore generoso alla comunità ecclesiale e ai poveri?",
+      "text_past": "Sono stato/a avido/a oppure ho mancato di donare con cuore generoso alla comunità ecclesiale o ai poveri.",
+      "detail": ""
+    },
+    "49": {
+      "text": "Ho indotto consapevolmente altri al peccato?",
+      "text_past": "Ho indotto consapevolmente altri al peccato.",
+      "detail": ""
+    },
+    "50": {
+      "text": "Ho mancato di fare di Dio una priorità nella mia vita?",
+      "text_past": "Ho mancato di fare di Dio una priorità nella mia vita.",
+      "detail": ""
+    },
+    "51": {
+      "text": "Ho agito in maniera egoista?",
+      "text_past": "Ho agito in maniera egoista.",
+      "detail": ""
+    },
+    "52": {
+      "text": "Ho partecipato in pratiche occulte?",
+      "text_past": "Ho partecipato in pratiche occulte.",
+      "detail": ""
+    },
+    "53": {
+      "text": "Ho peccato di accidia al lavoro o a casa?",
+      "text_past": "Ho peccato di accidia al lavoro o a casa.",
+      "detail": ""
+    },
+    "54": {
+      "text": "",
+      "text_past": "",
+      "detail": ""
+    },
+    "55": {
+      "text": "Sono stato vanitoso o orgoglioso?",
+      "text_past": "Sono stato vanitoso o orgoglioso.",
+      "detail": ""
+    },
+    "56": {
+      "text": "Ho peccato di golosità?",
+      "text_past": "Ho peccato di golosità.",
+      "detail": ""
+    },
+    "57": {
+      "text": "Sono stato iracondo?",
+      "text_past": "Sono stato iracondo.",
+      "detail": ""
+    }
+  },
+  "addbutton": {
+    "add-custom-sin": "",
+    "i-sinned-by": "",
+    "cancel": "",
+    "add": ""
+  },
+  "examineitem": {
+    "yes": ""
+  },
+  "priestbubble": {
+    "priest": ""
+  }
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -22,6 +22,24 @@ i18n
     // allow an empty value to count as invalid
     // https://www.i18next.com/principles/fallback#missing-values-for-existing-keys
     returnEmptyString: false,
+    react: {
+      transSupportBasicHtmlNodes: true,
+      transKeepBasicHtmlNodesFor: [
+        "br",
+        "strong",
+        "i",
+        "p",
+        "vatican",
+        "github",
+        "mass",
+        "osc",
+        "website",
+        "app",
+        "a",
+        "kbd",
+        "code",
+      ],
+    },
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default
     },

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -38,6 +38,7 @@ i18n
         "a",
         "kbd",
         "code",
+        "footer",
       ],
     },
     interpolation: {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -39,6 +39,7 @@ i18n
         "kbd",
         "code",
         "footer",
+        "githubicon",
       ],
     },
     interpolation: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,6 +1462,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.20.6":
+  version: 7.21.5
+  resolution: "@babel/runtime@npm:7.21.5"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 724e81d7c560d1a84fcf6c804e8daa05be42cdc1049943887ea160b5eff1199c6b56f6efc3afbd8841875abcb60d17e755eb02204fb9220009a010840921bcfb
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.18.10, @babel/template@npm:^7.3.3":
   version: 7.18.10
   resolution: "@babel/template@npm:7.18.10"
@@ -3176,6 +3185,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-class-fields@npm:^0.3.7":
+  version: 0.3.7
+  resolution: "acorn-class-fields@npm:0.3.7"
+  dependencies:
+    acorn-private-class-elements: ^0.2.7
+  peerDependencies:
+    acorn: ^6 || ^7 || ^8
+  checksum: 293aafcb03cbc224e7c2c5352f9980f1bff0565681c47074c90b82171514f9d42b928f32c8010c19a6afe5af2881458ef67e1cbcdd6f4062dd38e1bf3a825b6d
+  languageName: node
+  linkType: hard
+
+"acorn-dynamic-import@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "acorn-dynamic-import@npm:4.0.0"
+  peerDependencies:
+    acorn: ^6.0.0
+  checksum: ce61df77522b5eaee93f4a61043af9b059590d382bdbf5bf4a3717416d0cfb7bebbacb736d82764ba51381d2d55db4b27477384bb7e2642283941b52bcd9d008
+  languageName: node
+  linkType: hard
+
 "acorn-globals@npm:^6.0.0":
   version: 6.0.0
   resolution: "acorn-globals@npm:6.0.0"
@@ -3195,7 +3224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-jsx@npm:^5.3.2":
+"acorn-jsx@npm:^5.3.1, acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
   peerDependencies:
@@ -3215,10 +3244,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-private-class-elements@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "acorn-private-class-elements@npm:0.2.7"
+  peerDependencies:
+    acorn: ^6.1.0 || ^7 || ^8
+  checksum: fd6edc936a30c28622ce30dedaedc815ba64c845219bbf0b965b44466d4a0c8c3e8c02037085c9eecf4ffff5179441c8e0639689164735b24d30c61a70fbb351
+  languageName: node
+  linkType: hard
+
+"acorn-private-methods@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "acorn-private-methods@npm:0.3.3"
+  dependencies:
+    acorn-private-class-elements: ^0.2.7
+  peerDependencies:
+    acorn: ^6 || ^7 || ^8
+  checksum: dac318d03bfd104a0594c056a7aaa37386d7b08c2c72a7aa8d06e1c7b71c47888696db533a1e04e997d078bbba4e49b39561af4b0be8e4e5f08eb5ff971f15a1
+  languageName: node
+  linkType: hard
+
+"acorn-stage3@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "acorn-stage3@npm:4.0.0"
+  dependencies:
+    acorn-class-fields: ^0.3.7
+    acorn-private-methods: ^0.3.3
+    acorn-static-class-features: ^0.2.4
+  peerDependencies:
+    acorn: ^7.4 || ^8
+  checksum: 038c510d20c3f09444cab00686c90131cbd6e02d851dd64ea213100f0955f9d4e4a5dfdecd56a3f4d294d695ebc64d3d259b25e37fcaa113ee18980f2da7232c
+  languageName: node
+  linkType: hard
+
+"acorn-static-class-features@npm:^0.2.4":
+  version: 0.2.4
+  resolution: "acorn-static-class-features@npm:0.2.4"
+  dependencies:
+    acorn-private-class-elements: ^0.2.7
+  peerDependencies:
+    acorn: ^6.1.0 || ^7 || ^8
+  checksum: 432363817de3b8792e652f72f38230fe72d19fd34efa701b01b8f966622c97be3d64d2310f24468b76f11d4495b019b33e027d9618d9a941c94d5e7f91bd13bd
+  languageName: node
+  linkType: hard
+
 "acorn-walk@npm:^7.0.0, acorn-walk@npm:^7.1.1":
   version: 7.2.0
   resolution: "acorn-walk@npm:7.2.0"
   checksum: 7b52d5d6397f2d395ca878bdb0f56e583e69bc875521876d05fe2b6e293c21aca918b288c01bd18ac99b46b55a0f00a8d0e30fbdfb53c8e36e78ad1a65f73a4a
+  languageName: node
+  linkType: hard
+
+"acorn-walk@npm:^8.0.0":
+  version: 8.2.0
+  resolution: "acorn-walk@npm:8.2.0"
+  checksum: 93ffbdb8b35dda04313f1d6a94bdfdf8f929337f742e3a6d51b3026ced8471feb6a522646240809da44b0f576f4902ff2fa0c64292b3216478992aefcbde3278
   languageName: node
   linkType: hard
 
@@ -3228,6 +3308,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 2bde98c28c1be9a08e41e581179b776b43396c9486ce52b2b9848d73c53df38c516b7edba4bacdc84cabc9d7a3299f3b46ef240ae261c38dbf8ddd89f635bd32
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.0.4":
+  version: 8.8.2
+  resolution: "acorn@npm:8.8.2"
+  bin:
+    acorn: bin/acorn
+  checksum: ff4058b23372a00dbd1a32ebbe029b53e22198cf2dd70aed99a7715b07eb98c2f669f3ac27e969fcb3b15dbade7a6654e72dd4b845996ce5698520b122d1cc8c
   languageName: node
   linkType: hard
 
@@ -3435,6 +3524,15 @@ __metadata:
     normalize-path: ^3.0.0
     picomatch: ^2.0.4
   checksum: cd6c08eb8d435741a9de6f5695c75cfba747a50772929ca588235535c6a57d37f2c2b34057768f015fd92abb88108b122ed2e399faac6ae30363a8ca0b6107d0
+  languageName: node
+  linkType: hard
+
+"append-buffer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "append-buffer@npm:1.0.2"
+  dependencies:
+    buffer-equal: ^1.0.0
+  checksum: 3f205f30482cedf135f4aaf1266845ea13b237196c10e42ac6628604708b6b7bd9128abfa0a5c6351a0832fafa0855ecdb0eed979816b1b43278f063684f8e27
   languageName: node
   linkType: hard
 
@@ -3999,6 +4097,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-equal@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "buffer-equal@npm:1.0.1"
+  checksum: 1a262fc69ff62e1e12434bf2064c939c0e13e3bda7c47971cd5022ae0e1f8a8a0b86c057ed7a303857cbf207594c7e6d00707cc77938ee00bab9f8556d719e10
+  languageName: node
+  linkType: hard
+
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -4308,6 +4413,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clone-buffer@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "clone-buffer@npm:1.0.0"
+  checksum: 70d92e1482af3cfc4e1f1f620ac2a34c0a441da4760f46a250a5f75df7b5f054f27c4358467ba3915832b2a9674b469fa93b7f9e3bc97ade3227e20952ea3404
+  languageName: node
+  linkType: hard
+
+"clone-deep@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "clone-deep@npm:4.0.1"
+  dependencies:
+    is-plain-object: ^2.0.4
+    kind-of: ^6.0.2
+    shallow-clone: ^3.0.0
+  checksum: b0146d66cabc7e609d23d10155dcc88e2f74b03539b3b65f8a05f889500e2a78b6c6265a744445d009d512a1afa16836f62aa5737d462027142984c2d41130c8
+  languageName: node
+  linkType: hard
+
+"clone-stats@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "clone-stats@npm:1.0.0"
+  checksum: fc70411afba2115e5b2800b76ad434a79e0fe81d7ad8016c9351937fbec14a10c56314c5df545549bc5046a4b21b7bb2ee45a6393dcccf279abd5554c04629f2
+  languageName: node
+  linkType: hard
+
+"clone@npm:^2.1.1":
+  version: 2.1.2
+  resolution: "clone@npm:2.1.2"
+  checksum: 85232d66015d2d703dc59812e30049931d97c7815bf70569ae4fb7a66be257f46fcf47040e4e7050966ca195a9e615d59d73ba9e39fc37eedba1a76865f27ab1
+  languageName: node
+  linkType: hard
+
+"cloneable-readable@npm:^1.0.0":
+  version: 1.1.3
+  resolution: "cloneable-readable@npm:1.1.3"
+  dependencies:
+    inherits: ^2.0.1
+    process-nextick-args: ^2.0.0
+    readable-stream: ^2.3.5
+  checksum: b7dda8125e898a788ac6427003337920532658b8b62b8ae3ae1c45ca877e3159c51c260efeb89f5a23b18bc62031bfcd5d2dfe5beada4a657d93f5fd2c8b7e50
+  languageName: node
+  linkType: hard
+
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -4418,6 +4566,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^9.0.0":
+  version: 9.5.0
+  resolution: "commander@npm:9.5.0"
+  checksum: d6b8793132d89f24d138c35a6c53cf38da0d9f32a53d177114f43e7d663afb49fc8580c569dca5ed280c4d5ff53e461130b9200e8659b587eaf9c6b61fedda0b
+  languageName: node
+  linkType: hard
+
 "commander@npm:^9.3.0":
   version: 9.4.1
   resolution: "commander@npm:9.4.1"
@@ -4489,6 +4644,7 @@ __metadata:
     i18next: ^21.5.2
     i18next-browser-languagedetector: ^6.1.2
     i18next-http-backend: ^1.3.1
+    i18next-scanner: ^4.2.0
     lint-staged: ^13.0.3
     prettier: 2.7.1
     react: ^16.14.0
@@ -4540,7 +4696,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"convert-source-map@npm:^1.4.0, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
+"convert-source-map@npm:^1.4.0, convert-source-map@npm:^1.5.0, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
   version: 1.9.0
   resolution: "convert-source-map@npm:1.9.0"
   checksum: 0c0a4b8152c4b2f73b2ca2472337da4101358f582e97d2e0dfb98373ebd771066b221659cb1e33880793fad5c92be12d9558576b702e9123337ba17165daa09f
@@ -4997,6 +5153,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deepmerge@npm:^4.0.0":
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 59d9e3ef18059970256d35a6cb280c9058185e2d713cf768f29aab02afede348ee7593841f575b47ec4bbdfe244762724c9d5d2b25d593d98d6d2593d7138523
+  languageName: node
+  linkType: hard
+
 "deepmerge@npm:^4.2.2":
   version: 4.2.2
   resolution: "deepmerge@npm:4.2.2"
@@ -5354,6 +5517,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"duplexify@npm:^3.6.0":
+  version: 3.7.1
+  resolution: "duplexify@npm:3.7.1"
+  dependencies:
+    end-of-stream: ^1.0.0
+    inherits: ^2.0.1
+    readable-stream: ^2.0.0
+    stream-shift: ^1.0.0
+  checksum: 9581cdb8f6304fdaacb8bbe2b8b393a8da3ece3086dd24070601b70f08ca417305b4f3a94699b984c4981dceb6eebb4c132abfe0445baacfd04f2b66a0524cda
+  languageName: node
+  linkType: hard
+
 "eastasianwidth@npm:^0.2.0":
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
@@ -5437,6 +5612,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"end-of-stream@npm:^1.0.0, end-of-stream@npm:^1.1.0":
+  version: 1.4.4
+  resolution: "end-of-stream@npm:1.4.4"
+  dependencies:
+    once: ^1.4.0
+  checksum: 7da60e458bdb5e16c006a45e85ef3bc1e3791db5ba275b0913258ccddc8899acb9252c4ddbcce87bd1b46e2a3f97315aafb9f0c0330e8aac44defb504a9d3ccd
+  languageName: node
+  linkType: hard
+
 "enhanced-resolve@npm:^5.10.0":
   version: 5.10.0
   resolution: "enhanced-resolve@npm:5.10.0"
@@ -5444,6 +5628,13 @@ __metadata:
     graceful-fs: ^4.2.4
     tapable: ^2.2.0
   checksum: 4a7d376104f5c2ecacea9f71ad10a7ab3ae0f344e4c0f8c92a25915a1127b29b31c177396a120f75f530a1530ed153526c0f8baa07417d24d8b076369d306973
+  languageName: node
+  linkType: hard
+
+"ensure-type@npm:^1.5.0":
+  version: 1.5.1
+  resolution: "ensure-type@npm:1.5.1"
+  checksum: e00afec07986d56dd8c7622132dd63572caf29247916d549c131a63a975fd0aa5e810383c9e6c87f56795e93c3b1b4e43d396e5dcfd73f152fe21a6ab2573ecb
   languageName: node
   linkType: hard
 
@@ -5543,6 +5734,13 @@ __metadata:
     rst-selector-parser: ^2.2.3
     string.prototype.trim: ^1.2.1
   checksum: d84541f524b758a93995cd1322709791fa02554968abf568f113097a9b3cdfefa465f58d8cef092cb815f37420ad8f136052b79ebf870227480aff560b555af4
+  languageName: node
+  linkType: hard
+
+"eol@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "eol@npm:0.9.1"
+  checksum: c77ee68dbe5505f06bb3033d2294437385e579175248123613b36fce9ee707e0f94fae111e7beafb75f656794b5e96b709b9de2dfb2ac5d6ad10cda4cf6de99c
   languageName: node
   linkType: hard
 
@@ -5978,6 +6176,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esprima-next@npm:^5.7.0":
+  version: 5.8.4
+  resolution: "esprima-next@npm:5.8.4"
+  bin:
+    esparse: bin/esparse.js
+    esvalidate: bin/esvalidate.js
+  checksum: ec43c6b3ddc779158a5bc1b62783dc620477f7976677b225e2542358c39cd5f4bd054871fef6fb96d13c63286bf3fc7da97eba7a01f5e0321567eb50a1d0a37b
+  languageName: node
+  linkType: hard
+
 "esprima@npm:^4.0.0, esprima@npm:^4.0.1":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
@@ -6144,6 +6352,13 @@ __metadata:
     utils-merge: 1.0.1
     vary: ~1.1.2
   checksum: b3675a74759b8b38c4341507d26d50f01eda9e86d71ec03ff695b016fd7573702c591de6a63b28477cced061a9093603b8251e81da4a5b2081b6042a83755f0c
+  languageName: node
+  linkType: hard
+
+"extend@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "extend@npm:3.0.2"
+  checksum: 1406da1f0c4b00b839497e4cdd0ec4303ce2ae349144b7c28064a5073c93ce8c08da4e8fb1bc5cb459ffcdff30a35fc0fe54344eb88320e70100c1baea6f195c
   languageName: node
   linkType: hard
 
@@ -6326,6 +6541,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flush-write-stream@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "flush-write-stream@npm:1.1.1"
+  dependencies:
+    inherits: ^2.0.3
+    readable-stream: ^2.3.6
+  checksum: b8fa1fbfadd5c4b6df3cf2c34b3c408fe508a2899c536bafa339f679de545689997e907bd4ff61dd292942f8044fb2f293a5956dd8b601f6a5601617842d0dda
+  languageName: node
+  linkType: hard
+
 "follow-redirects@npm:^1.0.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
@@ -6435,6 +6660,16 @@ __metadata:
   dependencies:
     minipass: ^3.0.0
   checksum: e14a490658621cf1f7d8cbf9e92a9cc4dc7ce050418e4817e877e4531c438223db79f7a1774668087428d665a3de95f87014ce36c8afdc841fea42bcb782abcb
+  languageName: node
+  linkType: hard
+
+"fs-mkdirp-stream@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fs-mkdirp-stream@npm:1.0.0"
+  dependencies:
+    graceful-fs: ^4.1.11
+    through2: ^2.0.3
+  checksum: a432e19f94af5eefa6a5268ada83994caf94b4ba4898116261ce541c8680858144e23258cb6239aa49a991f94f51e07411e9b2612df1e6ea1f41be094e3e1f67
   languageName: node
   linkType: hard
 
@@ -6568,6 +6803,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob-parent@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "glob-parent@npm:3.1.0"
+  dependencies:
+    is-glob: ^3.1.0
+    path-dirname: ^1.0.0
+  checksum: 2827ec4405295b660d5ec3e400d84d548a22fc38c3de8fb4586258248bb24afc4515f377935fd80b8397debeb56ffe0d2f4e91233e3a1377fe0d1ddbceb605fc
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
@@ -6583,6 +6828,24 @@ __metadata:
   dependencies:
     is-glob: ^4.0.3
   checksum: 226293dc9d952acbe87d89eb4d87a1901a3eb64d9ec7338a65cb4dc8b337fe129d695e0bd5903b64f70c5044c6c3dfd5736fa18904f1d43d0136a752cb4d988f
+  languageName: node
+  linkType: hard
+
+"glob-stream@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "glob-stream@npm:6.1.0"
+  dependencies:
+    extend: ^3.0.0
+    glob: ^7.1.1
+    glob-parent: ^3.1.0
+    is-negated-glob: ^1.0.0
+    ordered-read-streams: ^1.0.0
+    pumpify: ^1.3.5
+    readable-stream: ^2.1.5
+    remove-trailing-separator: ^1.0.1
+    to-absolute-glob: ^2.0.0
+    unique-stream: ^2.0.2
+  checksum: b453b3da5a4507722597cfaf0b93756caa09cc8d7cdd13aabce04104804dc5b010afc93d72bcbd87b2f3f8f600e953a42bb2ebdeeb62586eba016fc9961b86b7
   languageName: node
   linkType: hard
 
@@ -6670,6 +6933,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graceful-fs@npm:^4.0.0, graceful-fs@npm:^4.1.11":
+  version: 4.2.11
+  resolution: "graceful-fs@npm:4.2.11"
+  checksum: 99533f7c73bafc139bfc435a628272226cb46dc2b9b3dba7395dcb6c19936db28961ad9fcd648f407c32f91998fb2102a2df4dd13951a9699c5c28e2145713a9
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
@@ -6681,6 +6951,15 @@ __metadata:
   version: 1.0.4
   resolution: "grapheme-splitter@npm:1.0.4"
   checksum: 6875e94add80360364a609e1fd0fe325e3b82326db2278dd36c1011a6bfc0e098811e791dedf9a88d4ae3f9d17a5c6a8d684948dd7b097f1f8d5ff905676e2b2
+  languageName: node
+  linkType: hard
+
+"gulp-sort@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "gulp-sort@npm:2.0.0"
+  dependencies:
+    through2: ^2.0.1
+  checksum: 4f43385ecf68fd230147bbb1702bbac2cc8970cfa008b18bc0915cf5c553da15fc0178b4b07a5fd37847733f4c36cdd981c2abec5b912523ef471d8a36308c78
   languageName: node
   linkType: hard
 
@@ -7075,6 +7354,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"i18next-scanner@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "i18next-scanner@npm:4.2.0"
+  dependencies:
+    acorn: ^8.0.4
+    acorn-dynamic-import: ^4.0.0
+    acorn-jsx: ^5.3.1
+    acorn-stage3: ^4.0.0
+    acorn-walk: ^8.0.0
+    chalk: ^4.1.0
+    clone-deep: ^4.0.0
+    commander: ^9.0.0
+    deepmerge: ^4.0.0
+    ensure-type: ^1.5.0
+    eol: ^0.9.1
+    esprima-next: ^5.7.0
+    gulp-sort: ^2.0.0
+    i18next: "*"
+    lodash: ^4.0.0
+    parse5: ^6.0.0
+    sortobject: ^4.0.0
+    through2: ^4.0.0
+    vinyl: ^2.2.0
+    vinyl-fs: ^3.0.1
+  bin:
+    i18next-scanner: bin/cli.js
+  checksum: 87f5a95452b4f2124bb3f6368981fa78dfd52309b55e9773a8d6528d23bbecfbf99732c280ecbf687fcb648279009982d99bf04c413bd1d6e1fc05d1ef603b7e
+  languageName: node
+  linkType: hard
+
+"i18next@npm:*":
+  version: 22.5.0
+  resolution: "i18next@npm:22.5.0"
+  dependencies:
+    "@babel/runtime": ^7.20.6
+  checksum: 399b0e63202ce622864ad43b73226e9253a4eb96142325d47ca490e7db51b458b005ac646590108d263c3c5e25fd3698856dd74268eb19d14e2b89eab99699e5
+  languageName: node
+  linkType: hard
+
 "i18next@npm:^21.5.2":
   version: 21.10.0
   resolution: "i18next@npm:21.10.0"
@@ -7263,6 +7581,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-absolute@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-absolute@npm:1.0.0"
+  dependencies:
+    is-relative: ^1.0.0
+    is-windows: ^1.0.1
+  checksum: 4b8ebda658ee6d820cc9ef77c7228f5048e4824cd0092415d41d94ae9d59d8cf27cb1a322958161059be1887d7d8bc85ef10e1444ed763731b45229b74bb7ad1
+  languageName: node
+  linkType: hard
+
 "is-arrayish@npm:^0.2.1":
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
@@ -7295,6 +7623,13 @@ __metadata:
     call-bind: ^1.0.2
     has-tostringtag: ^1.0.0
   checksum: 2ce475fb2a4993a27a128054646a848e51c4864469dd9a6a1a077f19cc292fc0454b0bf73a9614b3b87614b7facbc100ce004920d206f7097563283bba5fcee3
+  languageName: node
+  linkType: hard
+
+"is-buffer@npm:^1.1.5":
+  version: 1.1.6
+  resolution: "is-buffer@npm:1.1.6"
+  checksum: 336ec78f00e88efe6ff6f1aa08d06aadb942a6cd320e5f538ac00648378fb964743b3737c88ce7ce8741c067e4a3b78f596b83ee1a3c72dc2885ea0b03dc84f2
   languageName: node
   linkType: hard
 
@@ -7332,7 +7667,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-extglob@npm:^2.1.1":
+"is-extglob@npm:^2.1.0, is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
   checksum: ca623e2c56c893714a237aff645ec7caa8fea4d78868682af8d6803d7f0780323f8d566311e0dc6f942c886e81cbfa517597e48fcada7f3bf78a4d099eeecdd3
@@ -7360,6 +7695,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-glob@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "is-glob@npm:3.1.0"
+  dependencies:
+    is-extglob: ^2.1.0
+  checksum: 9911e04e28285c50bfd5ff79950c6cf712ed9d959ef640acba2daeca8a17a921494b78b3143d5d1749c4dc3bbeb296b8955064a4f17d014112f0c63a239322d6
+  languageName: node
+  linkType: hard
+
 "is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
@@ -7380,6 +7724,13 @@ __metadata:
   version: 1.0.0
   resolution: "is-module@npm:1.0.0"
   checksum: 2cbd41e2760874130b76aee84cc53120c4feef0d0f196fa665326857b444c8549909cc840f3f3a59652a7e8df46146a77f6c0f3f70a578704e03670975843e74
+  languageName: node
+  linkType: hard
+
+"is-negated-glob@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-negated-glob@npm:1.0.0"
+  checksum: add3803c20bc80cfc8151eb618fe9ee537d2cf5dfa77080100c3262207943627fc562e671d457f88bcc52b788dc588fdaf2bdbfa753f02d1449912aab5286069
   languageName: node
   linkType: hard
 
@@ -7420,6 +7771,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-plain-object@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "is-plain-object@npm:2.0.4"
+  dependencies:
+    isobject: ^3.0.1
+  checksum: 2f3232267366f3cdf13d53deda1b282ba7959f28ccb2ee8e0ca168f859f0d7126c27c846ebb7c2b9821a09bbda2e1835fd4020337ba666cf3c03dc256aab7ba1
+  languageName: node
+  linkType: hard
+
 "is-potential-custom-element-name@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
@@ -7441,6 +7801,15 @@ __metadata:
   version: 1.0.0
   resolution: "is-regexp@npm:1.0.0"
   checksum: b6c3ea4f405d31e20c9612f0480b5deb86d71477f3e08c78a889a8b7b4c9f9e9944b2621b997bede7b94b6f8607dc8333b521b6b69a2f8ad97c80d9eb47d04a9
+  languageName: node
+  linkType: hard
+
+"is-relative@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-relative@npm:1.0.0"
+  dependencies:
+    is-unc-path: ^1.0.0
+  checksum: a93a7b57d8fa2090757eb2193a58fcf318cd2963787d25cd756842b75c1d78a814105245deec16303a0df3e9263dbb587d55545ad684d6035b3534016a2bc4b3
   languageName: node
   linkType: hard
 
@@ -7506,12 +7875,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-unc-path@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-unc-path@npm:1.0.0"
+  dependencies:
+    unc-path-regex: ^0.1.2
+  checksum: ee43c89aa0dcf0292e50b0994cdb02d8c14bebea54d87f447915374982a66ffdf6e24780c7306c23a454a083c5b05a87dc84c9432bb17bbeddb1a4c6e52575c0
+  languageName: node
+  linkType: hard
+
+"is-utf8@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "is-utf8@npm:0.2.1"
+  checksum: c72f604d72b72f6a57f9b2e22c9b6f480e869b3f0efe141bd1dfbc36655225043ca8c1316ff8e343ef641cf80868c9e4a37345492f31402abd5ab68e09367977
+  languageName: node
+  linkType: hard
+
+"is-valid-glob@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-valid-glob@npm:1.0.0"
+  checksum: 7d61129ee5051409cd8b1ba738d1ce7108a20b39f297671f2c07a1d2737fc13d0cc476261b9a5fa6491252e6dbf0bc7cef04444b14455e929b285fddc2f48895
+  languageName: node
+  linkType: hard
+
 "is-weakref@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-weakref@npm:1.0.2"
   dependencies:
     call-bind: ^1.0.2
   checksum: 0d54eb2c58d79060feec60937eb38b2071e70fdc9746df5804fcdda263ad0bb62813d35b297dddf319ae05121d14cd9dc12ba4f591a3577d4876f46202a4fa19
+  languageName: node
+  linkType: hard
+
+"is-windows@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "is-windows@npm:1.0.2"
+  checksum: dd1ed8339a28c68fb52f05931c832488dafc90063e53b97a69ead219a5584d7f3e6e564731c2f983962ff5403afeb05365d88ce9af34c8dae76a14911020d73a
   languageName: node
   linkType: hard
 
@@ -7542,6 +7941,13 @@ __metadata:
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
   checksum: 7b437980bb77881a146fba85cfbdf01edc2b148673e9c2722a1e49661fea73adf524430a80fdbfb8ce9f60d43224e682c657c45030482bd39e0c488fc29b4afe
+  languageName: node
+  linkType: hard
+
+"isobject@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "isobject@npm:3.0.1"
+  checksum: b537a9ccdd8d40ec552fe7ff5db3731f1deb77581adf9beb8ae812f8d08acfa0e74b193159ac50fb01084d7ade06d114077f984e21b8340531241bf85be9a0ab
   languageName: node
   linkType: hard
 
@@ -8410,6 +8816,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lazystream@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "lazystream@npm:1.0.1"
+  dependencies:
+    readable-stream: ^2.0.5
+  checksum: f3655bd16d10d9b7a0130e0b366d163f2c565bc006d57516a04897aaa3356755954f663eb4b07cf4bf698b10e6d31745ca8dddad4a1ab13258450146257375a6
+  languageName: node
+  linkType: hard
+
+"lead@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "lead@npm:1.0.0"
+  dependencies:
+    flush-write-stream: ^1.0.2
+  checksum: 8cac773a199e178e2904cc2bf5392c841b825dbe49394da8ee062d69d6399a6931f6fc6b4c399e3c94f171e8f002e7b539beea9e90c0b4bc79711838bb6b2558
+  languageName: node
+  linkType: hard
+
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -8611,7 +9035,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
+"lodash@npm:^4.0.0, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.7.0":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 4983720b9abca930a4a46f18db163d7dad8dd00dbed6db0cc7b499b33b717cce69f80928b27bbb1ff2cbd3b19d251ee90669a8b5ea466072ca81c2ebe91e7468
@@ -9129,6 +9553,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"normalize-path@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "normalize-path@npm:2.1.1"
+  dependencies:
+    remove-trailing-separator: ^1.0.1
+  checksum: 9eb82b2f6abc1b99d820c36405d6b7a26a4cfa49d49d397eb2ad606b1295cb8e243b6071b18826907ae54a9a2b35373a83d827d843d19b76efcfa267d72cb301
+  languageName: node
+  linkType: hard
+
 "normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
@@ -9147,6 +9580,15 @@ __metadata:
   version: 6.1.0
   resolution: "normalize-url@npm:6.1.0"
   checksum: 5fb69e98c149f4a54a7bb0f1904cc524627c0d23327a9feafacacf135d01d9595c65e80ced6f27c17c1959541ea732815b604ff8a6ec52ec3fe7a391b92cfba9
+  languageName: node
+  linkType: hard
+
+"now-and-later@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "now-and-later@npm:2.0.1"
+  dependencies:
+    once: ^1.3.2
+  checksum: c3130e565f3ac4b8d3b6b329d2f8a8391c844a7c8718bc4747b77d1b431fa5259be92d8e88ba1dd0f79963539146dae735f46d48540e079367a917a9adad7488
   languageName: node
   linkType: hard
 
@@ -9243,7 +9685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.assign@npm:^4.1.0, object.assign@npm:^4.1.2, object.assign@npm:^4.1.3, object.assign@npm:^4.1.4":
+"object.assign@npm:^4.0.4, object.assign@npm:^4.1.0, object.assign@npm:^4.1.2, object.assign@npm:^4.1.3, object.assign@npm:^4.1.4":
   version: 4.1.4
   resolution: "object.assign@npm:4.1.4"
   dependencies:
@@ -9333,7 +9775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.3.2, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -9396,6 +9838,15 @@ __metadata:
     type-check: ^0.4.0
     word-wrap: ^1.2.3
   checksum: bdf5683f986d00e173e6034837b7b6a9e68c7e1a37d7684b240adf1758db9076cfb04c9f64be29327881bb06c5017afb8b65012c5f02d07b180e9f6f42595ffd
+  languageName: node
+  linkType: hard
+
+"ordered-read-streams@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "ordered-read-streams@npm:1.0.1"
+  dependencies:
+    readable-stream: ^2.0.1
+  checksum: f650ae7590d2696284001016bd4012200a9d4df41b7b25909019cdd8df207abb6ac84d70c91370808745bc0512933f54c34a668a7afc5ada384d8acc7b4380c4
   languageName: node
   linkType: hard
 
@@ -9511,7 +9962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:6.0.1":
+"parse5@npm:6.0.1, parse5@npm:^6.0.0":
   version: 6.0.1
   resolution: "parse5@npm:6.0.1"
   checksum: e312014edd76a6dc2eac35248ad53477b2594a7b92b7a00f66169483bb87c3d1d36660daddeb720457418dfe0893eb3ad1043085047fc3699167afa6834cb4c4
@@ -9541,6 +9992,13 @@ __metadata:
     no-case: ^3.0.4
     tslib: ^2.0.3
   checksum: 31708cecab221482edc81e2bd9b9d8282d72d4f1443b31f39725aa23768c5e42d93c4c014f1bc90f7f074e2a70d5091e4892ea370e550affc9ccf1d33c900bcd
+  languageName: node
+  linkType: hard
+
+"path-dirname@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "path-dirname@npm:1.0.2"
+  checksum: 4af73745fd97680c95b356b88450cd4c21d6825d0580620331382a6c910b76b3ced4aa2c4ddc2953d938bd758906b3d3aa2f56a2f601ec52763ed2cbbfc0106b
   languageName: node
   linkType: hard
 
@@ -10580,7 +11038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process-nextick-args@npm:~2.0.0":
+"process-nextick-args@npm:^2.0.0, process-nextick-args@npm:~2.0.0":
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
   checksum: ddeb0f07d0d5efa649c2c5e39d1afd0e3668df2b392d036c8a508b0034f7beffbc474b3c2f7fd3fed2dc4113cef8f1f7e00d05690df3c611b36f6c7efd7852d1
@@ -10671,6 +11129,27 @@ __metadata:
   version: 1.9.0
   resolution: "psl@npm:1.9.0"
   checksum: 310c7bee79348f66d2800e255457b2fbe1b438c66290b83ab71c0bf92a0dc60892e1f2f8c2467935656a08376b42847d951b116bdbce821dcfa078c89ff079d3
+  languageName: node
+  linkType: hard
+
+"pump@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pump@npm:2.0.1"
+  dependencies:
+    end-of-stream: ^1.1.0
+    once: ^1.3.1
+  checksum: 25c657a8f65bb7a8c3c9f806bd282c70a71b4ce41fab66800519fc0ed6b9ab05304569c2d0a1a5711bf39216392c4a583930c582e8fc760391f9f7b2fc6fe14e
+  languageName: node
+  linkType: hard
+
+"pumpify@npm:^1.3.5":
+  version: 1.5.1
+  resolution: "pumpify@npm:1.5.1"
+  dependencies:
+    duplexify: ^3.6.0
+    inherits: ^2.0.3
+    pump: ^2.0.0
+  checksum: c143607284efa8b91baf8e199e90a6560cf599bdb7928686d1f33d3d8bbf71f3bc8c673ed6747ed36b8771982376faa0d5dafc0580eb433c73a825031016aa77
   languageName: node
   linkType: hard
 
@@ -11084,6 +11563,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"readable-stream@npm:3":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
+  dependencies:
+    inherits: ^2.0.3
+    string_decoder: ^1.1.1
+    util-deprecate: ^1.0.1
+  checksum: 235f34af4ea7ac0c36945684f5fc709666ee27cbc35c08ce764369de7c86acbab4e27be5f2804568b832141e4c8c75b312e90dabf677be44cd463b64e4d35770
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.5, readable-stream@npm:^2.1.5, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.5, readable-stream@npm:^2.3.6, readable-stream@npm:~2.3.6":
+  version: 2.3.8
+  resolution: "readable-stream@npm:2.3.8"
+  dependencies:
+    core-util-is: ~1.0.0
+    inherits: ~2.0.3
+    isarray: ~1.0.0
+    process-nextick-args: ~2.0.0
+    safe-buffer: ~5.1.1
+    string_decoder: ~1.1.1
+    util-deprecate: ~1.0.1
+  checksum: 392f500c0b7815143b7fab282f23c87086cbbc845f1cc72d96962016f8046a14f4be843b5cd86322f1670cd7db8ffe08b16a63ff1db9153668bd6b4410d83aa2
+  languageName: node
+  linkType: hard
+
 "readable-stream@npm:^2.0.1":
   version: 2.3.7
   resolution: "readable-stream@npm:2.3.7"
@@ -11148,6 +11653,13 @@ __metadata:
   version: 1.4.2
   resolution: "regenerate@npm:1.4.2"
   checksum: 54275a99effd8a439bcdd88942b61f68a769133df841e90d94df9ae7c250cb6537c0a28dd913116539772b3415edbcb3c8d81c22275595d3755cf0353976dfa4
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.11":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: b7c850f32500838961c073b885f0b18671867e2f3626d0c6de18fc269147f57d1777fe42d045cb1b9c0dc31a69a5c456d684afeb9adb05cbd788dac521403e68
   languageName: node
   linkType: hard
 
@@ -11231,6 +11743,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remove-bom-buffer@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "remove-bom-buffer@npm:3.0.0"
+  dependencies:
+    is-buffer: ^1.1.5
+    is-utf8: ^0.2.1
+  checksum: c80bef6cb3788f37ea81bfc355c77da77f5c8963c50c4fdf20769e5804068e74f57dd6321b56c1c27a319768cbd8ad320afd92f4a63faf9b3c80ee06b4c9cb10
+  languageName: node
+  linkType: hard
+
+"remove-bom-stream@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "remove-bom-stream@npm:1.2.0"
+  dependencies:
+    remove-bom-buffer: ^3.0.0
+    safe-buffer: ^5.1.0
+    through2: ^2.0.3
+  checksum: 88a3f3004e0bb812276dc0ce1dd7760666440dad8ef621beb3620ddf5ede54bb35107042f0326b29113793519758a7661bb48d15892d0ce2f262051a5254576e
+  languageName: node
+  linkType: hard
+
+"remove-trailing-separator@npm:^1.0.1":
+  version: 1.1.0
+  resolution: "remove-trailing-separator@npm:1.1.0"
+  checksum: 17dadf3d1f7c51411b7c426c8e2d6a660359bc8dae7686137120483fe4345bfca4bf7460d2c302aa741a7886c932d8dad708d2b971669d74e0fb3ff9a4814408
+  languageName: node
+  linkType: hard
+
 "renderkid@npm:^3.0.0":
   version: 3.0.0
   resolution: "renderkid@npm:3.0.0"
@@ -11241,6 +11781,13 @@ __metadata:
     lodash: ^4.17.21
     strip-ansi: ^6.0.1
   checksum: 8dcdd6ab9bed5570c98d368704cd3384bad78cbbe2e93e03de31d7f234febcfaa0b0ef53ef0448f9e8844f32a361c0852598e33e1ce6533ee646ac704d22c6f7
+  languageName: node
+  linkType: hard
+
+"replace-ext@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "replace-ext@npm:1.0.1"
+  checksum: 29b0f4ec6fda1591eb9b7c2d300b3a099f61ab0f6870ac5c62a5fa1cc8208085b8c5bf77684e76dcddfc37734831449c92ac488bc2ba9d899476db6be9b4240c
   languageName: node
   linkType: hard
 
@@ -11285,6 +11832,15 @@ __metadata:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 0d29fc7012eb21f34d2637fa0602694f60e64c14bf5fbd5395b72f6ea5540a6906cbeef062edefc34c22fd802bfe8ae46ef936e6c4a3f1b1047390f9738dd76f
+  languageName: node
+  linkType: hard
+
+"resolve-options@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "resolve-options@npm:1.1.0"
+  dependencies:
+    value-or-function: ^3.0.0
+  checksum: a9387bac0c242b9346e9c1af24b9054eaa4ef5923ceee0be53d592ffb47506c5e1780dbbfa9f21bf631587635e7779eca7a5e8362187c1d6855407dc1dab1067
   languageName: node
   linkType: hard
 
@@ -11767,6 +12323,15 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"shallow-clone@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "shallow-clone@npm:3.0.1"
+  dependencies:
+    kind-of: ^6.0.2
+  checksum: e329e054c286f0681fd8a9e5c353999519332f12510a99e189ea9cfa0337adb6f1414639d44493418ef6790a693b78c354525269f5db25a9feddd8b4d7891a62
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -11897,6 +12462,13 @@ resolve@^2.0.0-next.3:
     ip: ^2.0.0
     smart-buffer: ^4.2.0
   checksum: 412b254d3253df7d93adecc051befc518f930bd75850815009c21392e8dd1a4e0c57863655e799837d330c24ca5e4bd96cd070b148d35e82ef358db45f0b25f6
+  languageName: node
+  linkType: hard
+
+"sortobject@npm:^4.0.0":
+  version: 4.16.0
+  resolution: "sortobject@npm:4.16.0"
+  checksum: 1534ef3fca578b3f404ac2ef484f9741ab32a12590f4d49eaa3a4991df41775f315d14e0228cfe6f597c8e79c2dbf3c323d64c203316ee5ce52a244e33000ada
   languageName: node
   linkType: hard
 
@@ -12051,6 +12623,13 @@ resolve@^2.0.0-next.3:
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: 57735269bf231176a60deb80f6d60214cb4a87663b0937e79497afe9aebe2597f8377fd28893f4d1776205f18dd0b927774a26b72051411ac5108e9e2dfc77d2
+  languageName: node
+  linkType: hard
+
+"stream-shift@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "stream-shift@npm:1.0.1"
+  checksum: 5d777b222e460dc660ee29acad4f99649eb8d0051d3cb648fc92f3f77557b33d0a8ad656291c2cfa87703204191534a6003c2b035606a699674d0bb600353ad3
   languageName: node
   linkType: hard
 
@@ -12530,6 +13109,35 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"through2-filter@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "through2-filter@npm:3.0.0"
+  dependencies:
+    through2: ~2.0.0
+    xtend: ~4.0.0
+  checksum: 0b667941b8970bb32221cc10d10c58bbe49c80abbc39bdb0f741e03fb442f5235f4df2ff79f1539c1fdf3c90bedb69d1db34640c84eb9582da7044eb5ce19e3d
+  languageName: node
+  linkType: hard
+
+"through2@npm:^2.0.0, through2@npm:^2.0.1, through2@npm:^2.0.3, through2@npm:~2.0.0":
+  version: 2.0.5
+  resolution: "through2@npm:2.0.5"
+  dependencies:
+    readable-stream: ~2.3.6
+    xtend: ~4.0.1
+  checksum: 7427403555ead550d3cbe11f69eb07797e27505fc365cf53572111556a7c08625adb5159cad0fc4b9f57babfd937692e34b3a8a20ba35072f4e85f83d340661c
+  languageName: node
+  linkType: hard
+
+"through2@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "through2@npm:4.0.2"
+  dependencies:
+    readable-stream: 3
+  checksum: 5a844792cf4fcdda0640ed3c619498724b2dfacfc24da438e1478bfd8d10a2831bd5824cf4ca8ec28a4fcd569b2acc7e8b0a673d269003009cb90e140e57a0ba
+  languageName: node
+  linkType: hard
+
 "through@npm:^2.3.8":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
@@ -12565,6 +13173,16 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"to-absolute-glob@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "to-absolute-glob@npm:2.0.2"
+  dependencies:
+    is-absolute: ^1.0.0
+    is-negated-glob: ^1.0.0
+  checksum: b2f4257e042a8923526f91ab1983ca3de33478ad0a12a945ef625387925ae11c47aabe8a45c234f86285a39dfa3caf1c9bede5363147d9b648ad30f44efbf78b
+  languageName: node
+  linkType: hard
+
 "to-fast-properties@npm:^2.0.0":
   version: 2.0.0
   resolution: "to-fast-properties@npm:2.0.0"
@@ -12578,6 +13196,15 @@ resolve@^2.0.0-next.3:
   dependencies:
     is-number: ^7.0.0
   checksum: 2b6001e314e4998a07137c197e333fac2f86d46d0593da90b678ae64e2daa07274b508f83cca09e6b3504cdf222497dcb5b7daceb6dc13a9a8872f58a27db907
+  languageName: node
+  linkType: hard
+
+"to-through@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "to-through@npm:2.0.0"
+  dependencies:
+    through2: ^2.0.3
+  checksum: c4b135b0984fb88e8462032cf4d8ed744c01f3eee869892260ea4b9a981994e7665d1774f2c5682a455a6a59c7f0b4bda70298540d3ccbf5ef04c8847f738534
   languageName: node
   linkType: hard
 
@@ -12746,6 +13373,13 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"unc-path-regex@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "unc-path-regex@npm:0.1.2"
+  checksum: 585e29357917a8b529e05db14a3f2e9486258a5826ca9c0eb4f9173c006968ceffba201766d2ff08d38a1e014b69c519294981b29e669a81ea357c0ffd6e326b
+  languageName: node
+  linkType: hard
+
 "uncontrollable@npm:^7.2.1":
   version: 7.2.1
   resolution: "uncontrollable@npm:7.2.1"
@@ -12806,6 +13440,16 @@ resolve@^2.0.0-next.3:
   dependencies:
     imurmurhash: ^0.1.4
   checksum: 10a2cca62a99b5f8178dafd9319a44423b894716c66fb0c3502ef351b8b1dce783512ec63439d6633129d546175d387615f5d54a545b0186c6573e6183d207b8
+  languageName: node
+  linkType: hard
+
+"unique-stream@npm:^2.0.2":
+  version: 2.3.1
+  resolution: "unique-stream@npm:2.3.1"
+  dependencies:
+    json-stable-stringify-without-jsonify: ^1.0.1
+    through2-filter: ^3.0.0
+  checksum: 9064f196d58c10ff774c340659e4c7f45f578176dc282212ecfa3864174159fe0ec2895e0804e5da22f23df92d3772cc02ba2510734fcb2ff17b8d975e0d9dab
   languageName: node
   linkType: hard
 
@@ -12946,10 +13590,71 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"value-or-function@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "value-or-function@npm:3.0.0"
+  checksum: ea8dfbd31d4e7336a1b5a8f2dc0dc6e623b3eb843e116170e094d952842542e5f29a565a15eda424ae1174897d7abf7fd8a21cd9284dbebf4dbd6611bd59e159
+  languageName: node
+  linkType: hard
+
 "vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 591f059f727ac1ba0d97cb7767f8583a03fcbb07db7be2b7dce838ede520ec0e958a41cb19077054769077fdc49a9b9a2dc391c83426bfee89c054b8cc7404bf
+  languageName: node
+  linkType: hard
+
+"vinyl-fs@npm:^3.0.1":
+  version: 3.0.3
+  resolution: "vinyl-fs@npm:3.0.3"
+  dependencies:
+    fs-mkdirp-stream: ^1.0.0
+    glob-stream: ^6.1.0
+    graceful-fs: ^4.0.0
+    is-valid-glob: ^1.0.0
+    lazystream: ^1.0.0
+    lead: ^1.0.0
+    object.assign: ^4.0.4
+    pumpify: ^1.3.5
+    readable-stream: ^2.3.3
+    remove-bom-buffer: ^3.0.0
+    remove-bom-stream: ^1.2.0
+    resolve-options: ^1.1.0
+    through2: ^2.0.0
+    to-through: ^2.0.0
+    value-or-function: ^3.0.0
+    vinyl: ^2.0.0
+    vinyl-sourcemap: ^1.1.0
+  checksum: d12dc2e6f644014e4e4f9c612d9693f9f15ebf5dd830fc15c63fe9102ee10b879afb93ff43b91e2abecea833b66ca44ccaf5a2f30bbe7b0e7bf1311ffe5127ca
+  languageName: node
+  linkType: hard
+
+"vinyl-sourcemap@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "vinyl-sourcemap@npm:1.1.0"
+  dependencies:
+    append-buffer: ^1.0.2
+    convert-source-map: ^1.5.0
+    graceful-fs: ^4.1.6
+    normalize-path: ^2.1.1
+    now-and-later: ^2.0.0
+    remove-bom-buffer: ^3.0.0
+    vinyl: ^2.0.0
+  checksum: 372d6f0797596bb7d86a3c86029a93f08a98816a615e418d482c77a2de95de5f65f46f6b488a56994d8dcb639b16b1e680b19e41e993479ef4729fc65cc45fb4
+  languageName: node
+  linkType: hard
+
+"vinyl@npm:^2.0.0, vinyl@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "vinyl@npm:2.2.1"
+  dependencies:
+    clone: ^2.1.1
+    clone-buffer: ^1.0.0
+    clone-stats: ^1.0.0
+    cloneable-readable: ^1.0.0
+    remove-trailing-separator: ^1.0.1
+    replace-ext: ^1.0.0
+  checksum: 9f4088a075cc3eb2ecbd88b09cb5c7571c4edb64d6ebb80eeaaf18ddb47bbca1ee2808dea4ae6ee338e38e60715c253c67b5f2fe34be630a914e54fae618db9c
   languageName: node
   linkType: hard
 
@@ -13592,7 +14297,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"xtend@npm:^4.0.2":
+"xtend@npm:^4.0.2, xtend@npm:~4.0.0, xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 37ee522a3e9fb9b143a400c30b21dc122aa8c9c9411c6afae1005a4617dc20a21765c114d544e37a6bb60c2733dd8ee0a44ed9e80d884ac78cccd30b5e0ab0da


### PR DESCRIPTION
Attempt to implement `i18next-scanner`.

As of the latest commits in the PR, there is just one minor detail to try to work out (which can be done even after the PR is merged):

While the configuration option `defaultValue` works fine for `t()` functions, however for `Trans` components the string value in English is being set in all language files, whether English or not. Instead it would be desirable for an empty value to be set in non English language files, while the source string is correctly set in the English language file. This perhaps needs to be handled within the `customTransform` function?
