### PR TITLE
Fix a css bug

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -41,7 +41,7 @@
   font-family: "Open Sans", sans-serif;
 }
 .column-container {
-  height: calc(100% - 7rem);
+  height: calc(100% - 4rem);
 }
 
 /* 100% height to fill vertically so we can scroll columns. */


### PR DESCRIPTION
The scrollable columns had too big a margin at the bottom, which takes up valuable real estate on small phones.