### PR TITLE
Fix English Translation Strings

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -423,5 +423,17 @@
       "text_past": "I allowed myself to be controlled by anger.",
       "detail": ""
     }
+  },
+  "addbutton": {
+    "add-custom-sin": "Add custom sin",
+    "i-sinned-by": "I sinned by…",
+    "cancel": "Cancel",
+    "add": "Add"
+  },
+  "examineitem": {
+    "yes": "Yes"
+  },
+  "priestbubble": {
+    "priest": "Priest"
   }
 }


### PR DESCRIPTION
We recently added some strings to translations, but forgot to add them to the translation file. This adds them so they're not missing from the prod website at https://confessit.app.

https://github.com/kas-catholic/confessit-web/pull/57