### PR TITLE
Fix navbar buttons on localized pages

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -94,7 +94,8 @@ const { title, bodyClass = "" } = Astro.props;
           />
 
           {
-            Astro.url.pathname == localizePath("/") && (
+            (Astro.url.pathname == localizePath("/") ||
+              Astro.url.pathname == `${localizePath("/")}/`) && (
               <button
                 id="add-sin-button"
                 class="btn btn-secondary"
@@ -107,7 +108,8 @@ const { title, bodyClass = "" } = Astro.props;
           }
 
           {
-            Astro.url.pathname == localizePath("/") && (
+            (Astro.url.pathname == localizePath("/") ||
+              Astro.url.pathname == `${localizePath("/")}/`) && (
               <button
                 id="clear-button"
                 class="btn btn-accent"


### PR DESCRIPTION
In prod, the root page was coming through as `/es/` rather than `/es`. Make the buttons work correctly with either form.