### PR TITLE
`i18next-scanner` can't scan `.astro` files out of the box

### DIFF
--- a/i18next-scanner.config-langs.cjs
+++ b/i18next-scanner.config-langs.cjs
@@ -1,18 +1,19 @@
 /**
  * i18next-scanner configuration for languages other than English
- * For languages other than English, keys should be populated with an empty value
+ * for which keys should be populated with an empty value
  * not with the default value within `Trans` components for example
  * Only way to achieve this is a separate config for all other languages
  */
 
-const fs = require("fs");
 const chalk = require("chalk");
+const path = require("path");
+const HTML = require("html-parse-stringify");
 
 module.exports = {
   input: [
-    "src/**/*.{js,jsx}",
+    "src/**/*.{js,jsx,astro}",
     // Use ! to filter out files or directories
-    "!src/**/*.test.{js,jsx}",
+    "!src/**/*.test.{js,jsx,astro}",
     "!**/node_modules/**",
   ],
   output: "./",
@@ -21,44 +22,9 @@ module.exports = {
     removeUnusedKeys: false,
     sort: true,
     attr: false,
-    func: {
-      list: ["i18next.t", "i18n.t", "t"],
-      extensions: [".js", ".jsx"],
-    },
-    trans: {
-      component: "Trans",
-      i18nKey: "i18nKey",
-      defaultsKey: "defaults",
-      extensions: [".js", ".jsx"],
-      fallbackKey: function (ns, value) {
-        return sha1(value);
-      },
-      // https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0
-      supportBasicHtmlNodes: true, // Enables keeping the name of simple nodes (e.g. <br/>) in translations instead of indexed keys.
-      keepBasicHtmlNodesFor: [
-        "br",
-        "strong",
-        "i",
-        "p",
-        "vatican",
-        "github",
-        "mass",
-        "osc",
-        "website",
-        "app",
-        "a",
-        "kbd",
-        "code",
-        "footer",
-        "githubicon",
-      ], // Which nodes are allowed to be kept in translations during defaultValue generation of <Trans>.
-      // https://github.com/acornjs/acorn/tree/master/acorn#interface
-      acorn: {
-        ecmaVersion: 2020,
-        sourceType: "module", // defaults to 'module'
-      },
-    },
-    lngs: ["es", "de", "it", "pt-BR"],
+    func: false,
+    trans: false,
+    lngs: ["es", "de", "it", "pt-BR", "fr"],
     defaultLng: "en",
     ns: ["translation"],
     defaultNs: "translation",
@@ -84,23 +50,150 @@ module.exports = {
     allowDynamicKeys: false,
     compatibilityJSON: "v4",
   },
-  transform: function customTransform(file, enc, done) {
+  transform: function (file, enc, done) {
     "use strict";
-    const content = fs.readFileSync(file.path, enc);
+    const parser = this.parser;
+    const currentTime = new Date().toLocaleTimeString();
+    const temp_content = file.contents.toString(enc);
+
     let count = 0;
     let transCount = 0;
 
-    const parser = this.parser;
-
-    parser.parseFuncFromString(content, {}, (key, options) => {
-      parser.set(key, options);
-      ++count;
-    });
-
-    parser.parseTransFromString(content, {}, (key, options) => {
-      parser.set(key, options);
-      ++transCount;
-    });
+    if (path.extname(file.path) === ".astro") {
+      // Remove Astro frontmatter (anything between `---` fences)
+      const frontMatterStripped = temp_content
+        .replace(/^---[\s\S]*?---/, "")
+        .trim();
+      console.log(
+        `${currentTime} i18next-scanner: Parsing Astro file ${file.relative}...`,
+      );
+      //console.log(`${currentTime} i18next-scanner: file contents stripped of Astro frontmatter: ${frontMatterStripped}`);
+      parser.parseFuncFromString(
+        frontMatterStripped,
+        {
+          list: ["i18next.t", "i18n.t", "t"],
+          extensions: [".js", ".jsx", ".astro"],
+        },
+        (key, options) => {
+          parser.set(key, options);
+          ++count;
+        },
+      );
+      const extractText = (nodes) => {
+        nodes.forEach((node) => {
+          if (node.type === "tag" && node.name === "Trans") {
+            const content = HTML.stringify([node]);
+            //console.log(`${currentTime} i18next-scanner: Parsing Trans in ${file.path}...`, content);
+            parser.parseTransFromString(
+              content,
+              {
+                component: "Trans",
+                i18nKey: "i18nKey",
+                defaultsKey: "defaults",
+                extensions: [".js", ".jsx", ".astro"],
+                fallbackKey: function (ns, value) {
+                  return sha1(value);
+                },
+                // https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0
+                supportBasicHtmlNodes: true, // Enables keeping the name of simple nodes (e.g. <br/>) in translations instead of indexed keys.
+                keepBasicHtmlNodesFor: [
+                  "br",
+                  "strong",
+                  "i",
+                  "p",
+                  "vatican",
+                  "github",
+                  "mass",
+                  "osc",
+                  "website",
+                  "app",
+                  "a",
+                  "kbd",
+                  "code",
+                  "footer",
+                  "githubicon",
+                ], // Which nodes are allowed to be kept in translations during defaultValue generation of the Trans component.
+                // https://github.com/acornjs/acorn/tree/master/acorn#interface
+                acorn: {
+                  ecmaVersion: 2020,
+                  sourceType: "module",
+                },
+              },
+              (key, options) => {
+                parser.set(key, options);
+                ++transCount;
+              },
+            );
+          } else if (node.children) {
+            extractText(node.children);
+          }
+        });
+      };
+      try {
+        const ast = HTML.parse(frontMatterStripped);
+        //console.log(`${currentTime} i18next-scanner: Parsing HTML in ${file.path}...`);
+        extractText(ast);
+      } catch (err) {
+        console.log(
+          `${currentTime} i18next-scanner: Error parsing HTML in ${file.path}: ${err.message}`,
+        );
+      }
+    } else {
+      console.log(
+        `${currentTime} i18next-scanner: Parsing js or jsx file ${file.relative}...`,
+      );
+      parser.parseFuncFromString(
+        temp_content,
+        {
+          list: ["i18next.t", "i18n.t", "t"],
+          extensions: [".js", ".jsx", ".astro"],
+        },
+        (key, options) => {
+          parser.set(key, options);
+          ++count;
+        },
+      );
+      parser.parseTransFromString(
+        temp_content,
+        {
+          component: "Trans",
+          i18nKey: "i18nKey",
+          defaultsKey: "defaults",
+          extensions: [".js", ".jsx", ".astro"],
+          fallbackKey: function (ns, value) {
+            return sha1(value);
+          },
+          // https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0
+          supportBasicHtmlNodes: true, // Enables keeping the name of simple nodes (e.g. <br/>) in translations instead of indexed keys.
+          keepBasicHtmlNodesFor: [
+            "br",
+            "strong",
+            "i",
+            "p",
+            "vatican",
+            "github",
+            "mass",
+            "osc",
+            "website",
+            "app",
+            "a",
+            "kbd",
+            "code",
+            "footer",
+            "githubicon",
+          ], // Which nodes are allowed to be kept in translations during defaultValue generation of <Trans>.
+          // https://github.com/acornjs/acorn/tree/master/acorn#interface
+          acorn: {
+            ecmaVersion: 2020,
+            sourceType: "module", // defaults to 'module'
+          },
+        },
+        (key, options) => {
+          parser.set(key, options);
+          ++transCount;
+        },
+      );
+    }
 
     if (count > 0 || transCount > 0) {
       console.log(

--- a/i18next-scanner.config-langs.cjs
+++ b/i18next-scanner.config-langs.cjs
@@ -8,6 +8,43 @@
 const chalk = require("chalk");
 const path = require("path");
 const HTML = require("html-parse-stringify");
+const transCompOptions = {
+  component: "Trans",
+  i18nKey: "i18nKey",
+  defaultsKey: "defaults",
+  extensions: [".js", ".jsx", ".astro"],
+  fallbackKey: function (ns, value) {
+    return sha1(value);
+  },
+  // https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0
+  supportBasicHtmlNodes: true, // Enables keeping the name of simple nodes (e.g. <br/>) in translations instead of indexed keys.
+  keepBasicHtmlNodesFor: [
+    "br",
+    "strong",
+    "i",
+    "p",
+    "vatican",
+    "github",
+    "mass",
+    "osc",
+    "website",
+    "app",
+    "a",
+    "kbd",
+    "code",
+    "footer",
+    "githubicon",
+  ], // Which nodes are allowed to be kept in translations during defaultValue generation of <Trans>.
+  // https://github.com/acornjs/acorn/tree/master/acorn#interface
+  acorn: {
+    ecmaVersion: 2020,
+    sourceType: "module", // defaults to 'module'
+  },
+};
+const funcOptions = {
+  list: ["i18next.t", "i18n.t", "t"],
+  extensions: [".js", ".jsx", ".astro"],
+};
 
 module.exports = {
   input: [
@@ -70,10 +107,7 @@ module.exports = {
       //console.log(`${currentTime} i18next-scanner: file contents stripped of Astro frontmatter: ${frontMatterStripped}`);
       parser.parseFuncFromString(
         frontMatterStripped,
-        {
-          list: ["i18next.t", "i18n.t", "t"],
-          extensions: [".js", ".jsx", ".astro"],
-        },
+        funcOptions,
         (key, options) => {
           parser.set(key, options);
           ++count;
@@ -86,39 +120,7 @@ module.exports = {
             //console.log(`${currentTime} i18next-scanner: Parsing Trans in ${file.path}...`, content);
             parser.parseTransFromString(
               content,
-              {
-                component: "Trans",
-                i18nKey: "i18nKey",
-                defaultsKey: "defaults",
-                extensions: [".js", ".jsx", ".astro"],
-                fallbackKey: function (ns, value) {
-                  return sha1(value);
-                },
-                // https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0
-                supportBasicHtmlNodes: true, // Enables keeping the name of simple nodes (e.g. <br/>) in translations instead of indexed keys.
-                keepBasicHtmlNodesFor: [
-                  "br",
-                  "strong",
-                  "i",
-                  "p",
-                  "vatican",
-                  "github",
-                  "mass",
-                  "osc",
-                  "website",
-                  "app",
-                  "a",
-                  "kbd",
-                  "code",
-                  "footer",
-                  "githubicon",
-                ], // Which nodes are allowed to be kept in translations during defaultValue generation of the Trans component.
-                // https://github.com/acornjs/acorn/tree/master/acorn#interface
-                acorn: {
-                  ecmaVersion: 2020,
-                  sourceType: "module",
-                },
-              },
+              transCompOptions,
               (key, options) => {
                 parser.set(key, options);
                 ++transCount;
@@ -142,52 +144,13 @@ module.exports = {
       console.log(
         `${currentTime} i18next-scanner: Parsing js or jsx file ${file.relative}...`,
       );
-      parser.parseFuncFromString(
-        temp_content,
-        {
-          list: ["i18next.t", "i18n.t", "t"],
-          extensions: [".js", ".jsx", ".astro"],
-        },
-        (key, options) => {
-          parser.set(key, options);
-          ++count;
-        },
-      );
+      parser.parseFuncFromString(temp_content, funcOptions, (key, options) => {
+        parser.set(key, options);
+        ++count;
+      });
       parser.parseTransFromString(
         temp_content,
-        {
-          component: "Trans",
-          i18nKey: "i18nKey",
-          defaultsKey: "defaults",
-          extensions: [".js", ".jsx", ".astro"],
-          fallbackKey: function (ns, value) {
-            return sha1(value);
-          },
-          // https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0
-          supportBasicHtmlNodes: true, // Enables keeping the name of simple nodes (e.g. <br/>) in translations instead of indexed keys.
-          keepBasicHtmlNodesFor: [
-            "br",
-            "strong",
-            "i",
-            "p",
-            "vatican",
-            "github",
-            "mass",
-            "osc",
-            "website",
-            "app",
-            "a",
-            "kbd",
-            "code",
-            "footer",
-            "githubicon",
-          ], // Which nodes are allowed to be kept in translations during defaultValue generation of <Trans>.
-          // https://github.com/acornjs/acorn/tree/master/acorn#interface
-          acorn: {
-            ecmaVersion: 2020,
-            sourceType: "module", // defaults to 'module'
-          },
-        },
+        transCompOptions,
         (key, options) => {
           parser.set(key, options);
           ++transCount;
@@ -197,7 +160,7 @@ module.exports = {
 
     if (count > 0 || transCount > 0) {
       console.log(
-        `i18next-scanner: t() count=${chalk.cyan(
+        `${currentTime} i18next-scanner: t() count=${chalk.cyan(
           count,
         )}, Trans count=${chalk.cyan(transCount)}, file=${chalk.yellow(
           JSON.stringify(file.relative),

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1,0 +1,389 @@
+{
+  "about": {
+    "about_confession": "",
+    "about_confession_end": "",
+    "about_confession_intro": "",
+    "about_confessit": "",
+    "about_confessit_text": "",
+    "about_the_developer": "",
+    "about_this_app": "",
+    "can_i_help_with_translations": "",
+    "can_i_help_write_code": "",
+    "ccc_quote": "",
+    "confessit_is_open_source": "",
+    "confessit_is_translated": "",
+    "if_you_find": "",
+    "information": "",
+    "information_you_enter": "",
+    "mike_kasberg": "",
+    "open_source": "",
+    "please_be_respectful": "",
+    "privacy": "",
+    "this_app_is_designed": "",
+    "this_website": "",
+    "we_welcome_new_contributions": "",
+    "where_to_find": ""
+  },
+  "addbutton": {
+    "add": "",
+    "add-custom-sin": "",
+    "cancel": "",
+    "i-sinned-by": ""
+  },
+  "commandments": {
+    "1": {
+      "description": "",
+      "text": "",
+      "title": ""
+    },
+    "2": {
+      "description": "",
+      "text": "",
+      "title": ""
+    },
+    "3": {
+      "description": "",
+      "text": "",
+      "title": ""
+    },
+    "4": {
+      "description": "",
+      "text": "",
+      "title": ""
+    },
+    "5": {
+      "description": "",
+      "text": "",
+      "title": ""
+    },
+    "6": {
+      "description": "",
+      "text": "",
+      "title": ""
+    },
+    "7": {
+      "description": "",
+      "text": "",
+      "title": ""
+    },
+    "8": {
+      "description": "",
+      "text": "",
+      "title": ""
+    },
+    "9": {
+      "description": "",
+      "text": "",
+      "title": ""
+    },
+    "10": {
+      "description": "",
+      "text": "",
+      "title": ""
+    },
+    "11": {
+      "description": "",
+      "text": "",
+      "title": ""
+    }
+  },
+  "examine_list": {
+    "examine": ""
+  },
+  "help": {
+    "basic_usage": "",
+    "confessit_help": "",
+    "data_persistence": "",
+    "data_persistence_text": "",
+    "step_1": "",
+    "step_2": "",
+    "step_3": "",
+    "step_4": ""
+  },
+  "navbar": {
+    "about": "",
+    "clear": "",
+    "help": "",
+    "prayers": ""
+  },
+  "prayers": {
+    "act_of_contrition": "",
+    "act_of_contrition_text": "",
+    "another_act_of_contrition": "",
+    "another_act_of_contrition_text": "",
+    "hail_holy_queen": "",
+    "hail_holy_queen_text": "",
+    "hail_mary": "",
+    "hail_mary_text": "",
+    "our_father": "",
+    "our_father_text": "",
+    "prayer_before_confession": "",
+    "prayer_before_confession_text": "",
+    "prayers": "",
+    "thanksgiving_after_confession": "",
+    "thanksgiving_after_confession_text": ""
+  },
+  "priestbubble": {
+    "priest": ""
+  },
+  "sins": {
+    "1": {
+      "detail": "",
+      "text": "",
+      "text_past": ""
+    },
+    "2": {
+      "detail": "",
+      "text": "",
+      "text_past": ""
+    },
+    "3": {
+      "detail": "",
+      "text": "",
+      "text_past": ""
+    },
+    "4": {
+      "detail": "",
+      "text": "",
+      "text_past": ""
+    },
+    "5": {
+      "text": "",
+      "text_past": ""
+    },
+    "6": {
+      "text": "",
+      "text_past": ""
+    },
+    "7": {
+      "detail": "",
+      "text": "",
+      "text_past": ""
+    },
+    "8": {
+      "detail": "",
+      "text": "",
+      "text_past": ""
+    },
+    "9": {
+      "detail": "",
+      "text": "",
+      "text_past": ""
+    },
+    "10": {
+      "detail": "",
+      "text": "",
+      "text_past": ""
+    },
+    "11": {
+      "detail": "",
+      "text": "",
+      "text_past": ""
+    },
+    "12": {
+      "text": "",
+      "text_past": ""
+    },
+    "13": {
+      "text": "",
+      "text_past": ""
+    },
+    "14": {
+      "text": "",
+      "text_past": ""
+    },
+    "15": {
+      "text": "",
+      "text_past": ""
+    },
+    "16": {
+      "text": "",
+      "text_past": ""
+    },
+    "17": {
+      "text": "",
+      "text_past": ""
+    },
+    "18": {
+      "text": "",
+      "text_past": ""
+    },
+    "19": {
+      "text": "",
+      "text_past": ""
+    },
+    "20": {
+      "text": "",
+      "text_past": ""
+    },
+    "21": {
+      "detail": "",
+      "text": "",
+      "text_past": ""
+    },
+    "22": {
+      "text": "",
+      "text_past": ""
+    },
+    "23": {
+      "text": "",
+      "text_past": ""
+    },
+    "24": {
+      "text": "",
+      "text_past": ""
+    },
+    "25": {
+      "text": "",
+      "text_past": ""
+    },
+    "26": {
+      "text": "",
+      "text_past": ""
+    },
+    "27": {
+      "text": "",
+      "text_past": ""
+    },
+    "28": {
+      "text": "",
+      "text_past": ""
+    },
+    "29": {
+      "text": "",
+      "text_past": ""
+    },
+    "30": {
+      "text": "",
+      "text_past": ""
+    },
+    "31": {
+      "text": "",
+      "text_past": ""
+    },
+    "32": {
+      "text": "",
+      "text_past": ""
+    },
+    "33": {
+      "text": "",
+      "text_past": ""
+    },
+    "34": {
+      "text": "",
+      "text_past": ""
+    },
+    "35": {
+      "text": "",
+      "text_past": ""
+    },
+    "36": {
+      "text": "",
+      "text_past": ""
+    },
+    "37": {
+      "text": "",
+      "text_past": ""
+    },
+    "38": {
+      "text": "",
+      "text_past": ""
+    },
+    "39": {
+      "text": "",
+      "text_past": ""
+    },
+    "40": {
+      "text": "",
+      "text_past": ""
+    },
+    "41": {
+      "text": "",
+      "text_past": ""
+    },
+    "42": {
+      "text": "",
+      "text_past": ""
+    },
+    "43": {
+      "text": "",
+      "text_past": ""
+    },
+    "44": {
+      "text": "",
+      "text_past": ""
+    },
+    "45": {
+      "text": "",
+      "text_past": ""
+    },
+    "46": {
+      "text": "",
+      "text_past": ""
+    },
+    "47": {
+      "text": "",
+      "text_past": ""
+    },
+    "48": {
+      "text": "",
+      "text_past": ""
+    },
+    "49": {
+      "text": "",
+      "text_past": ""
+    },
+    "50": {
+      "text": "",
+      "text_past": ""
+    },
+    "51": {
+      "text": "",
+      "text_past": ""
+    },
+    "52": {
+      "text": "",
+      "text_past": ""
+    },
+    "53": {
+      "text": "",
+      "text_past": ""
+    },
+    "54": {
+      "text": "",
+      "text_past": ""
+    },
+    "55": {
+      "text": "",
+      "text_past": ""
+    },
+    "56": {
+      "text": "",
+      "text_past": ""
+    },
+    "57": {
+      "text": "",
+      "text_past": ""
+    }
+  },
+  "sins_list": {
+    "review": ""
+  },
+  "walkthrough": {
+    "amen": "",
+    "bless_me_father": "",
+    "god_the_father_of_mercies": "",
+    "in_the_name_of": "",
+    "thanks_be_to_god": "",
+    "the_lord_has_freed_you": "",
+    "these_are_my_sins": "",
+    "walkthrough": "",
+    "your_confessor_may_offer": "",
+    "your_confessor_will_assign": ""
+  },
+  "welcome": {
+    "body": "",
+    "ok": "",
+    "title": ""
+  }
+}

--- a/src/components/AddSinModal.jsx
+++ b/src/components/AddSinModal.jsx
@@ -16,22 +16,24 @@ const AddSinModal = ({ addCustomSin }) => {
   return (
     <dialog id="AddSinModal" className="modal modal-bottom lg:modal-middle">
       <div className="modal-box">
-        <h3 className="text-lg font-bold">{t("addbutton.add-custom-sin")}</h3>
+        <h3 className="text-lg font-bold">
+          {t("addbutton.add-custom-sin", "Add custom sin")}
+        </h3>
         <textarea
           className="my-4 textarea textarea-bordered w-full"
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
-          placeholder={t("addbutton.i-sinned-by")}
+          placeholder={t("addbutton.i-sinned-by", "I sinned by…")}
         ></textarea>
         <div className="modal-action">
           <form method="dialog">
             <button className="btn" onClick={handleCancel}>
-              {t("addbutton.cancel")}
+              {t("addbutton.cancel", "Cancel")}
             </button>
           </form>
           <form method="dialog">
             <button className="btn btn-primary" onClick={handleSubmit}>
-              {t("addbutton.add")}
+              {t("addbutton.add", "Add")}
             </button>
           </form>
         </div>

--- a/src/components/ConfessIt.jsx
+++ b/src/components/ConfessIt.jsx
@@ -88,7 +88,7 @@ const ConfessIt = () => {
         className="h-full"
       >
         <SwiperSlide className="h-full">
-          <Column title={t("examine_list.examine")}>
+          <Column title={t("examine_list.examine", "Examine")}>
             <ExamineList
               sinsdb={sinsdb}
               selectedSinIds={selectedSinIds}
@@ -98,12 +98,12 @@ const ConfessIt = () => {
           </Column>
         </SwiperSlide>
         <SwiperSlide>
-          <Column title={t("sins_list.review")}>
+          <Column title={t("sins_list.review", "Review")}>
             <SinsList sinsList={sinsList} onRemoveSinItem={removeSinItem} />
           </Column>
         </SwiperSlide>
         <SwiperSlide>
-          <Column title={t("walkthrough.walkthrough")}>
+          <Column title={t("walkthrough.walkthrough", "Walkthrough")}>
             <Walkthrough sinsList={sinsList} />
           </Column>
         </SwiperSlide>

--- a/src/components/SpeechBubble.jsx
+++ b/src/components/SpeechBubble.jsx
@@ -2,14 +2,14 @@ import { t } from "i18next";
 
 const SpeechBubble = ({ isPriest, children }) => {
   const clazz = isPriest ? "chat-start" : "chat-end font-bold";
-  const bubbleClass = isPriest ? "" : "chat-bubble-primary";
+  const bubbleClass = isPriest ? "" : " chat-bubble-primary";
 
   return (
     <div className={`chat mb-4 ${clazz}`}>
       {isPriest && (
-        <div className="chat-header">{t("priestbubble.priest")}</div>
+        <div className="chat-header">{t("priestbubble.priest", "Priest")}</div>
       )}
-      <div className={`chat-bubble p-4 ${bubbleClass}`}>{children}</div>
+      <div className={`chat-bubble${bubbleClass} p-4`}>{children}</div>
     </div>
   );
 };

--- a/src/components/Walkthrough.jsx
+++ b/src/components/Walkthrough.jsx
@@ -12,22 +12,37 @@ const Walkthrough = ({ sinsList }) => {
   return (
     <div>
       <SpeechBubble isPriest={true}>
-        {t("walkthrough.in_the_name_of")}
+        {t(
+          "walkthrough.in_the_name_of",
+          "In the name of the Father, and of the Son, and of the Holy Spirit. Amen.",
+        )}
       </SpeechBubble>
       <SpeechBubble isPriest={false}>
-        {t("walkthrough.bless_me_father")}
+        {t(
+          "walkthrough.bless_me_father",
+          "Bless me father, for I have sinned. It has been ____ since my last confession, and these are my sins:",
+        )}
       </SpeechBubble>
 
       {sinCards}
 
       <SpeechBubble isPriest={false}>
-        {t("walkthrough.these_are_my_sins")}
+        {t(
+          "walkthrough.these_are_my_sins",
+          "These are my sins, and I am sorry for them with all my heart.",
+        )}
       </SpeechBubble>
       <SpeechBubble isPriest={true}>
-        {t("walkthrough.your_confessor_may_offer")}
+        {t(
+          "walkthrough.your_confessor_may_offer",
+          "(Your confessor may offer you some advice or have a short conversation with you.)",
+        )}
       </SpeechBubble>
       <SpeechBubble isPriest={true}>
-        {t("walkthrough.your_confessor_will_assign")}
+        {t(
+          "walkthrough.your_confessor_will_assign",
+          "(Your confessor will assign you penance.) Now pray the act of contrition.",
+        )}
       </SpeechBubble>
       <SpeechBubble isPriest={false}>
         <Trans t={t} i18nKey="prayers.act_of_contrition_text">
@@ -48,12 +63,17 @@ const Walkthrough = ({ sinsList }) => {
       <SpeechBubble isPriest={true}>
         {t("walkthrough.god_the_father_of_mercies")}
       </SpeechBubble>
-      <SpeechBubble isPriest={false}>{t("walkthrough.amen")}</SpeechBubble>
+      <SpeechBubble isPriest={false}>
+        {t("walkthrough.amen", "Amen.")}
+      </SpeechBubble>
       <SpeechBubble isPriest={true}>
-        {t("walkthrough.the_lord_has_freed_you")}
+        {t(
+          "walkthrough.the_lord_has_freed_you",
+          "The Lord has freed you from sin. Go in peace.",
+        )}
       </SpeechBubble>
       <SpeechBubble isPriest={false}>
-        {t("walkthrough.thanks_be_to_god")}
+        {t("walkthrough.thanks_be_to_god", "Thanks be to God.")}
       </SpeechBubble>
     </div>
   );

--- a/src/components/WelcomeModal.jsx
+++ b/src/components/WelcomeModal.jsx
@@ -19,7 +19,7 @@ const WelcomeModal = () => {
   return (
     <dialog id="WelcomeModalId" className="modal modal-bottom lg:modal-middle">
       <div className="modal-box">
-        <h3 className="text-lg font-bold">{t("welcome.title")}</h3>
+        <h3 className="text-lg font-bold">{t("welcome.title", "Welcome!")}</h3>
         <p>
           <span className="text-primary font-bold">ConfessIt</span>{" "}
           <Trans t={t} i18nKey="welcome.body">
@@ -46,7 +46,7 @@ const WelcomeModal = () => {
         <div className="modal-action">
           <form method="dialog">
             <button className="btn btn-primary" onClick={handleClose}>
-              {t("welcome.ok")}
+              {t("welcome.ok", "OK")}
             </button>
           </form>
         </div>

--- a/src/data/DummyTranslation.jsx
+++ b/src/data/DummyTranslation.jsx
@@ -1,0 +1,588 @@
+import { t } from "i18next";
+
+const DummyTranslation = () => {
+  return (
+    <div>
+      <h1>
+        dummy component that allows the i18next-scanner to pick up on
+        commandments and sins translations
+      </h1>
+      <span>
+        {t(
+          "commandments.1.description",
+          "I am the Lord your God, who brought you out of the land of Egypt, out of the house of bondage. You shall have no other gods before me… you shall not bow down to them or serve them; for I the Lord your God am a jealous God… showing steadfast love to thousands of those who love me and keep my commandments. (Ex 20:2-6) The capital sins of pride and gluttony are often considered to break this commandment.",
+        )}
+      </span>
+      <span>
+        {t(
+          "commandments.1.text",
+          "You shall have no other gods before Me. (Ex 20:3)",
+        )}
+      </span>
+      <span>{t("commandments.1.title", "First Commandment")}</span>
+      <span>
+        {t(
+          "commandments.2.description",
+          "You shall not take the name of the Lord your God in vain; for the Lord will not hold him guiltless who takes his name in vain. (Ex 20:7)",
+        )}
+      </span>
+      <span>
+        {t(
+          "commandments.2.text",
+          "You shall not take the name of the Lord your God in vain. (Ex 20:7)",
+        )}
+      </span>
+      <span>{t("commandments.2.title", "Second Commandment")}</span>
+      <span>
+        {t(
+          "commandments.3.description",
+          "Remember the sabbath day, to keep it holy. Six days you shall labor, and do all your work; but the seventh day is a sabbath to the Lord your God; in it you shall not do any work… For in six days the Lord made heaven and earth, the sea, and all that is in them, and rested the seventh day; therefore the Lord blessed the sabbath day and hallowed it. (Ex 20:8-11)",
+        )}
+      </span>
+      <span>
+        {t(
+          "commandments.3.text",
+          "Remember the sabbath day, to keep it holy. (Ex 20:8)",
+        )}
+      </span>
+      <span>{t("commandments.3.title", "Third Commandment")}</span>
+      <span>
+        {t(
+          "commandments.4.description",
+          "Honor your father and mother, that your days may be long in the land which the Lord your God gives you. (Ex 20:12)",
+        )}
+      </span>
+      <span>
+        {t(
+          "commandments.4.text",
+          "Honor your father and your mother. (Ex 20:12)",
+        )}
+      </span>
+      <span>{t("commandments.4.title", "Fourth Commandment")}</span>
+      <span>
+        {t(
+          "commandments.5.description",
+          "You shall not kill. (Ex 20:13) The capital sin of anger is often associated with this commandment.",
+        )}
+      </span>
+      <span>{t("commandments.5.text", "You shall not kill. (Ex 20:13)")}</span>
+      <span>{t("commandments.5.title", "Fifth Commandment")}</span>
+      <span>
+        {t(
+          "commandments.6.description",
+          "You shall not commit adultery. (Ex 20:14) The capital sin of lust breaks this commandment.",
+        )}
+      </span>
+      <span>
+        {t("commandments.6.text", "You shall not commit adultery. (Ex 20:14)")}
+      </span>
+      <span>{t("commandments.6.title", "Sixth Commandment")}</span>
+      <span>
+        {t(
+          "commandments.7.description",
+          "You shall not steal. (Ex 20:15) The capital sins of greed and sloth are often considered to break this commandment.",
+        )}
+      </span>
+      <span>{t("commandments.7.text", "You shall not steal. (Ex 20:15)")}</span>
+      <span>{t("commandments.7.title", "Seventh Commandment")}</span>
+      <span>
+        {t(
+          "commandments.8.description",
+          "You shall not bear false witness against your neighbor. (Ex 20:16)",
+        )}
+      </span>
+      <span>
+        {t(
+          "commandments.8.text",
+          "You shall not bear false witness against your neighbor. (Ex 20:16)",
+        )}
+      </span>
+      <span>{t("commandments.8.title", "Eighth Commandment")}</span>
+      <span>
+        {t(
+          "commandments.9.description",
+          "You shall not covet your neighbor's wife. (Ex 20:17) The capital sin of jealousy can break this commandment.",
+        )}
+      </span>
+      <span>
+        {t(
+          "commandments.9.text",
+          "You shall not covet your neighbor's wife. (Ex 20:17)",
+        )}
+      </span>
+      <span>{t("commandments.9.title", "Ninth Commandment")}</span>
+      <span>
+        {t(
+          "commandments.10.description",
+          "You shall not covet your neighbor's house… or his manservant, or his maidservant, or his ox, or his ass, or anything that is your neighbor's. (Ex 20:17) The capital sin of jealousy can break this commandment.",
+        )}
+      </span>
+      <span>
+        {t(
+          "commandments.10.text",
+          "You shall not covet your neighbor's goods. (Ex 20:17)",
+        )}
+      </span>
+      <span>{t("commandments.10.title", "Tenth Commandment")}</span>
+      <span>
+        {t(
+          "commandments.11.description",
+          "The precepts of the Church are set in the context of a moral life bound to and nourished by liturgical life. The obligatory character of these positive laws decreed by the pastoral authorities is meant to guarantee to the faithful the very necessary minimum in the spirit of prayer and moral effort, in the growth in love of God and neighbor (CCC 2041).",
+        )}
+      </span>
+      <span>
+        {t(
+          "commandments.11.text",
+          "The precepts of the Catholic Church are the minimum requirements that all Catholics should fulfill.",
+        )}
+      </span>
+      <span>{t("commandments.11.title", "Precepts of the Church")}</span>
+      <span>
+        {t(
+          "sins.1.detail",
+          "To obey in faith is to submit freely to the word that has been heard, because its truth is guaranteed by God, who is Truth itself (CCC 144). It is important to believe in all of the teachings of the church.",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.1.text",
+          "Did I refuse to believe the teachings of the Catholic Church?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.1.text_past",
+          "I refused to believe the teachings of the Catholic Church.",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.2.detail",
+          "The first commandment forbids honoring gods other than the one Lord who has revealed himself to his people (CCC 2110). It is wrong to practice a religion other than Catholicism because it weakens our relationship with our Lord.",
+        )}
+      </span>
+      <span>
+        {t("sins.2.text", "Did I practice any religion besides Catholicism?")}
+      </span>
+      <span>
+        {t("sins.2.text_past", "I practiced a religion besides Catholicism.")}
+      </span>
+      <span>
+        {t(
+          "sins.3.detail",
+          "Presuming God's mercy is hoping to obtain forgiveness without conversion and glory without merit (CCC 2092). It is wrong to do something immoral because you expect God to forgive you.",
+        )}
+      </span>
+      <span>{t("sins.3.text", "Did I presume God's mercy?")}</span>
+      <span>{t("sins.3.text_past", "I presumed God's mercy.")}</span>
+      <span>
+        {t(
+          "sins.4.detail",
+          "Adoring God, praying to him, offering him the worship that belongs to him, fulfilling the promises and vows made to him are acts of the virtue of religion which fall under obedience to the first commandment (CCC 2135). Prayer is important because without prayer we cannot have a relationship with God.",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.4.text",
+          "How is my prayer life? Do I need to pray more often?",
+        )}
+      </span>
+      <span>{t("sins.4.text_past", "I need to pray more often.")}</span>
+      <span>{t("sins.5.detail", "")}</span>
+      <span>
+        {t(
+          "sins.5.text",
+          "Our culture often conflicts with Catholic ideals. Did I fail to stand up for Catholic moral values?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.5.text_past",
+          "I failed to stand up for Catholic moral values.",
+        )}
+      </span>
+      <span>{t("sins.6.detail", "")}</span>
+      <span>{t("sins.6.text", "Did I use foul language?")}</span>
+      <span>{t("sins.6.text_past", "I used foul language.")}</span>
+      <span>
+        {t(
+          "sins.7.detail",
+          "The second commandment forbids every improper use of God's name. Blasphemy is the use of the name of God, of Jesus Christ, of the Virgin Mary, and of the saints in an offensive way (CCC 2162).",
+        )}
+      </span>
+      <span>{t("sins.7.text", "Did I use God's name without respect?")}</span>
+      <span>{t("sins.7.text_past", "I used God's name without respect.")}</span>
+      <span>
+        {t(
+          "sins.8.detail",
+          "Respect for His name is an expression of the respect owed to the mystery of God himself and to the whole sacred reality it evokes (CCC 2144).",
+        )}
+      </span>
+      <span>{t("sins.8.text", "Did I insult God?")}</span>
+      <span>{t("sins.8.text_past", "I insulted God.")}</span>
+      <span>
+        {t(
+          "sins.9.detail",
+          'The first precept of the Catholic church is "You shall attend Mass on Sundays and holy days of obligation and rest from servile labor" (CCC 2042). As Catholics, we look forward to celebrating the Eucharist every Sunday. It is a sin to skip mass because it weakens our relationship with God.',
+        )}
+      </span>
+      <span>{t("sins.9.text", "Did I skip mass on Sunday?")}</span>
+      <span>{t("sins.9.text_past", "I skipped mass on Sunday.")}</span>
+      <span>
+        {t(
+          "sins.10.detail",
+          'The first precept of the Catholic church is "You shall attend Mass on Sundays and holy days of obligation and rest from servile labor" (CCC 2042). As Catholics, we look forward to celebrating the Eucharist on holy days of obligation. It is a sin to skip mass because it weakens our relationship with God.',
+        )}
+      </span>
+      <span>
+        {t("sins.10.text", "Did I skip mass on a holy day of obligation?")}
+      </span>
+      <span>
+        {t("sins.10.text_past", "I skipped mass on a holy day of obligation.")}
+      </span>
+      <span>
+        {t(
+          "sins.11.detail",
+          "Come to church early, approach the Lord, and confess your sins, repent in prayer… Be present at the sacred and divine liturgy, conclude its prayer and do not leave before dismissal… (CCC 2178). It is also rude and distracting to others who are worshipping to arrive late or leave early.",
+        )}
+      </span>
+      <span>
+        {t("sins.11.text", "Did I arrive to mass late or leave early?")}
+      </span>
+      <span>
+        {t("sins.11.text_past", "I arrived to mass late or left early.")}
+      </span>
+      <span>{t("sins.12.detail", "")}</span>
+      <span>{t("sins.12.text", "Did I disobey my parents?")}</span>
+      <span>{t("sins.12.text_past", "I disobeyed my parents.")}</span>
+      <span>{t("sins.13.detail", "")}</span>
+      <span>
+        {t(
+          "sins.13.text",
+          "Did I fail to raise my children in the Catholic faith?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.13.text_past",
+          "I failed to raise my children in the Catholic faith.",
+        )}
+      </span>
+      <span>{t("sins.14.detail", "")}</span>
+      <span>
+        {t("sins.14.text", "Did I fail to care for my elderly relatives?")}
+      </span>
+      <span>
+        {t("sins.14.text_past", "I failed to care for my elderly relatives.")}
+      </span>
+      <span>{t("sins.15.detail", "")}</span>
+      <span>{t("sins.15.text", "Did I neglect my family?")}</span>
+      <span>{t("sins.15.text_past", "I neglected my family.")}</span>
+      <span>{t("sins.16.detail", "")}</span>
+      <span>{t("sins.16.text", "Did I disobey any responsible adult?")}</span>
+      <span>{t("sins.16.text_past", "I disobeyed a responsible adult.")}</span>
+      <span>{t("sins.17.detail", "")}</span>
+      <span>
+        {t(
+          "sins.17.text",
+          "Did I fail to teach my children about their human sexuality?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.17.text_past",
+          "I failed to teach my children about their human sexuality.",
+        )}
+      </span>
+      <span>{t("sins.18.detail", "")}</span>
+      <span>{t("sins.18.text", "Did I break a just law?")}</span>
+      <span>{t("sins.18.text_past", "I broke a just law.")}</span>
+      <span>{t("sins.19.detail", "")}</span>
+      <span>{t("sins.19.text", "Did I physically hurt anyone?")}</span>
+      <span>{t("sins.19.text_past", "I physically hurt someone.")}</span>
+      <span>{t("sins.20.detail", "")}</span>
+      <span>
+        {t(
+          "sins.20.text",
+          "Did I have an abortion? Did I participate in an abortion?",
+        )}
+      </span>
+      <span>
+        {t("sins.20.text_past", "I had or participated in an abortion.")}
+      </span>
+      <span>
+        {t(
+          "sins.21.detail",
+          '"Every action which, whether in anticipation of the conjugal act, or in its accomplishment, or in the development of its natural consequences, proposes, whether as an end or as a means, to render procreation impossible is intrinsically evil" (CCC 2370). "Legitimate intentions on the part of the spouses do not justify recourse to morally unacceptable means (for example, direct sterilization or contraception)" (CCC 2399). Artificial contraception is wrong because it makes a beautiful act of love into something selfish.',
+        )}
+      </span>
+      <span>{t("sins.21.text", "Did I use artificial birth control?")}</span>
+      <span>{t("sins.21.text_past", "I used artificial birth control.")}</span>
+      <span>{t("sins.22.detail", "")}</span>
+      <span>{t("sins.22.text", "Did I attempt suicide?")}</span>
+      <span>{t("sins.22.text_past", "I attempted suicide.")}</span>
+      <span>{t("sins.23.detail", "")}</span>
+      <span>{t("sins.23.text", "Did I participate in euthanasia?")}</span>
+      <span>{t("sins.23.text_past", "I participated in Euthanasia.")}</span>
+      <span>{t("sins.24.detail", "")}</span>
+      <span>{t("sins.24.text", "Did I abuse drugs or alcohol?")}</span>
+      <span>{t("sins.24.text_past", "I abused drugs or alcohol.")}</span>
+      <span>{t("sins.25.detail", "")}</span>
+      <span>{t("sins.25.text", "Did I have sex outside marriage?")}</span>
+      <span>{t("sins.25.text_past", "I had sex outside marriage.")}</span>
+      <span>{t("sins.26.detail", "")}</span>
+      <span>{t("sins.26.text", "Am I guilty of the sin of lust?")}</span>
+      <span>{t("sins.26.text_past", "I am guilty of the sin of lust.")}</span>
+      <span>{t("sins.27.detail", "")}</span>
+      <span>{t("sins.27.text", "Did I look at pornography?")}</span>
+      <span>{t("sins.27.text_past", "I looked at pornography.")}</span>
+      <span>{t("sins.28.detail", "")}</span>
+      <span>{t("sins.28.text", "Did I act on homosexual desires?")}</span>
+      <span>{t("sins.28.text_past", "I acted on homosexual desires.")}</span>
+      <span>{t("sins.29.detail", "")}</span>
+      <span>
+        {t("sins.29.text", "Did I fail to honor my husband or wife?")}
+      </span>
+      <span>
+        {t("sins.29.text_past", "I failed to honor my husband or wife.")}
+      </span>
+      <span>{t("sins.30.detail", "")}</span>
+      <span>{t("sins.30.text", "Did I read erotic literature?")}</span>
+      <span>{t("sins.30.text_past", "I read erotic literature.")}</span>
+      <span>{t("sins.31.detail", "")}</span>
+      <span>{t("sins.31.text", "Did I engage in sexually immoral acts?")}</span>
+      <span>
+        {t("sins.31.text_past", "I engaged in sexually immoral acts.")}
+      </span>
+      <span>{t("sins.32.detail", "")}</span>
+      <span>
+        {t(
+          "sins.32.text",
+          "Did I give in to overly passionate kissing for pleasure?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.32.text_past",
+          "I gave in to overly passionate kissing for pleasure.",
+        )}
+      </span>
+      <span>{t("sins.33.detail", "")}</span>
+      <span>
+        {t("sins.33.text", "Did I steal anything? If so, to what extent?")}
+      </span>
+      <span>
+        {t(
+          "sins.33.text_past",
+          "I stole something. (To such and such an extent.)",
+        )}
+      </span>
+      <span>{t("sins.34.detail", "")}</span>
+      <span>
+        {t("sins.34.text", "Did I pirate movies, music, or software?")}
+      </span>
+      <span>
+        {t("sins.34.text_past", "I pirated movies, music, or software.")}
+      </span>
+      <span>{t("sins.35.detail", "")}</span>
+      <span>{t("sins.35.text", "Did I lie or cheat?")}</span>
+      <span>{t("sins.35.text_past", "I lied or cheated.")}</span>
+      <span>{t("sins.36.detail", "")}</span>
+      <span>{t("sins.36.text", "Did I gossip about others?")}</span>
+      <span>{t("sins.36.text_past", "I gossiped about others.")}</span>
+      <span>{t("sins.37.detail", "")}</span>
+      <span>
+        {t(
+          "sins.37.text",
+          "Did I fail to fast on Ash Wednesday and Good Friday?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.37.text_past",
+          "I failed to fast on Ash Wednesday or Good Friday.",
+        )}
+      </span>
+      <span>{t("sins.38.detail", "")}</span>
+      <span>
+        {t(
+          "sins.38.text",
+          "Did I fail to abstain from meat on Fridays of Lent and Ash Wednesday?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.38.text_past",
+          "I failed to abstain from meat on a Friday during Lent or Ash Wednesday.",
+        )}
+      </span>
+      <span>{t("sins.39.detail", "")}</span>
+      <span>
+        {t(
+          "sins.39.text",
+          "Did I fail to receive the Eucharist at least once during Easter?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.39.text_past",
+          "I failed to receive the Eucharist at least once during Easter.",
+        )}
+      </span>
+      <span>{t("sins.40.detail", "")}</span>
+      <span>
+        {t(
+          "sins.40.text",
+          "Did I fail to fast for an hour before receiving the Eucharist?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.40.text_past",
+          "I failed to fast for an hour before receiving the Eucharist.",
+        )}
+      </span>
+      <span>{t("sins.41.detail", "")}</span>
+      <span>
+        {t(
+          "sins.41.text",
+          "Did I receive the Eucharist in a state of mortal sin?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.41.text_past",
+          "I received the Eucharist in a state of mortal sin.",
+        )}
+      </span>
+      <span>{t("sins.42.detail", "")}</span>
+      <span>
+        {t("sins.42.text", "Did I intentionally hide something at confession?")}
+      </span>
+      <span>
+        {t("sins.42.text_past", "I intentionally hid something at confession.")}
+      </span>
+      <span>{t("sins.43.detail", "")}</span>
+      <span>
+        {t(
+          "sins.43.text",
+          "Was I too busy to rest and spend time with my family on Sunday?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.43.text_past",
+          "I was too busy to rest and spend time with my family on Sunday.",
+        )}
+      </span>
+      <span>{t("sins.44.detail", "")}</span>
+      <span>
+        {t(
+          "sins.44.text",
+          "Was I jealous of someone else's wife/husband or fiancée/fiancé?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.44.text_past",
+          "I was jealous of someone else's wife/husband or fiancée/fiancé.",
+        )}
+      </span>
+      <span>{t("sins.45.detail", "")}</span>
+      <span>
+        {t(
+          "sins.45.text",
+          "Was I jealous of something that belongs to someone else?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.45.text_past",
+          "I was jealous of something that belongs to someone else.",
+        )}
+      </span>
+      <span>{t("sins.46.detail", "")}</span>
+      <span>
+        {t(
+          "sins.46.text",
+          "Did I vote for a candidate or policy that does not uphold my Catholic values?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.46.text_past",
+          "I voted for a candidate or policy that does not uphold my Catholic values.",
+        )}
+      </span>
+      <span>{t("sins.47.detail", "")}</span>
+      <span>
+        {t(
+          "sins.47.text",
+          "Did I listen to music or watch TV or a movie that have a bad influence on me?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.47.text_past",
+          "I listened to music or watched TV or a movie that had a bad influence on me.",
+        )}
+      </span>
+      <span>{t("sins.48.detail", "")}</span>
+      <span>
+        {t(
+          "sins.48.text",
+          "Was I greedy, or did I fail to give generously to my church and to the poor?",
+        )}
+      </span>
+      <span>
+        {t(
+          "sins.48.text_past",
+          "I was greedy or failed to give generously to my church or to the poor.",
+        )}
+      </span>
+      <span>{t("sins.49.detail", "")}</span>
+      <span>{t("sins.49.text", "Did I knowingly lead others into sin?")}</span>
+      <span>{t("sins.49.text_past", "I knowingly led others into sin.")}</span>
+      <span>{t("sins.50.detail", "")}</span>
+      <span>
+        {t("sins.50.text", "Did I fail to make God a priority in my life?")}
+      </span>
+      <span>
+        {t("sins.50.text_past", "I failed to make God a priority in my life.")}
+      </span>
+      <span>{t("sins.51.detail", "")}</span>
+      <span>{t("sins.51.text", "Have I acted selfishly?")}</span>
+      <span>{t("sins.51.text_past", "I acted selfishly.")}</span>
+      <span>{t("sins.52.detail", "")}</span>
+      <span>{t("sins.52.text", "Did I participate in occult practices?")}</span>
+      <span>
+        {t("sins.52.text_past", "I participated in occult practices.")}
+      </span>
+      <span>{t("sins.53.detail", "")}</span>
+      <span>
+        {t("sins.53.text", "Have I been slothful at work or at home?")}
+      </span>
+      <span>
+        {t("sins.53.text_past", "I was slothful at work or at home.")}
+      </span>
+      <span>{t("sins.54.detail", "")}</span>
+      <span>{t("sins.54.text", "Have I been lazy with my school work?")}</span>
+      <span>{t("sins.54.text_past", "I was lazy with my school work.")}</span>
+      <span>{t("sins.55.detail", "")}</span>
+      <span>{t("sins.55.text", "Have I been prideful or vain?")}</span>
+      <span>{t("sins.55.text_past", "I was prideful or vain.")}</span>
+      <span>{t("sins.56.detail", "")}</span>
+      <span>{t("sins.56.text", "Have I committed the sin of gluttony?")}</span>
+      <span>{t("sins.56.text_past", "I am guilty of gluttony.")}</span>
+      <span>{t("sins.57.detail", "")}</span>
+      <span>
+        {t("sins.57.text", "Have I allowed myself to be controlled by anger?")}
+      </span>
+      <span>
+        {t("sins.57.text_past", "I allowed myself to be controlled by anger.")}
+      </span>
+    </div>
+  );
+};
+
+export default DummyTranslation;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -114,7 +114,7 @@ const { title, bodyClass = "" } = Astro.props;
               <button
                 id="clear-button"
                 class="btn btn-accent"
-                title={t("navbar.clear")}
+                title={t("navbar.clear", "Clear")}
               >
                 <TrashIcon className="h-5" />
               </button>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,9 +6,9 @@ import { Trans } from "astro-i18next/components";
 changeLanguage("en");
 ---
 
-<Container title={t("navbar.about")}>
+<Container title={t("navbar.about", "About")}>
   <div class="prose lg:prose-lg mx-auto max-w-[48rem]">
-    <h1>{t("about.about_confessit")}</h1>
+    <h1>{t("about.about_confessit", "About ConfessIt")}</h1>
 
     <p>
       <Trans i18nKey="about.about_confessit_text">
@@ -25,9 +25,16 @@ changeLanguage("en");
       </Trans>
     </p>
 
-    <h2>{t("about.about_confession")}</h2>
+    <h2>{t("about.about_confession", "About Confession")}</h2>
 
-    <p>{t("about.about_confession_intro")}</p>
+    <p>
+      {
+        t(
+          "about.about_confession_intro",
+          "Confession is the holy sacrament by which Catholics obtain pardon from God's mercy for their sins, and are thus reconciled with the Church, the community of believers, the Body of Christ.",
+        )
+      }
+    </p>
     <blockquote>
       <Trans i18nKey="about.ccc_quote">
         <p>
@@ -106,9 +113,16 @@ changeLanguage("en");
       </Trans>
     </p>
 
-    <p>{t("about.about_confession_end")}</p>
+    <p>
+      {
+        t(
+          "about.about_confession_end",
+          "When you go to confession, typically, you will have the choice of kneeling anonymously behind a screen or sitting face-to-face with your confessor.Don't be nervous about going to confession! Whatever you confess, your priest has heard it before. Remember, he is there to help you.",
+        )
+      }
+    </p>
 
-    <h2>{t("about.about_this_app")}</h2>
+    <h2>{t("about.about_this_app", "About This App")}</h2>
 
     <p>
       <Trans i18nKey="about.this_app_is_designed">
@@ -118,7 +132,14 @@ changeLanguage("en");
       </Trans>
     </p>
 
-    <p>{t("about.please_be_respectful")}</p>
+    <p>
+      {
+        t(
+          "about.please_be_respectful",
+          "Please be respectful of those around you when you use this app. I recommend that you turn your phone off when you're inside your church, and use this app before you arrive. If you do use this app inside your church or during confession, please ensure your phone is in silent mode.",
+        )
+      }
+    </p>
 
     <p>
       <Trans i18nKey="about.this_website">
@@ -144,7 +165,7 @@ changeLanguage("en");
       </Trans>
     </p>
 
-    <h2>{t("about.privacy")}</h2>
+    <h2>{t("about.privacy", "Privacy")}</h2>
     <p>
       <Trans i18nKey="about.information_you_enter">
         Information you enter into this app is only stored on your device. It is
@@ -158,7 +179,7 @@ changeLanguage("en");
       </Trans>
     </p>
 
-    <h2>{t("about.open_source")}</h2>
+    <h2>{t("about.open_source", "Open Source")}</h2>
     <p>
       <Trans i18nKey="about.confessit_is_open_source">
         ConfessIt is open source. We develop the app on
@@ -170,7 +191,9 @@ changeLanguage("en");
       </Trans>
     </p>
 
-    <h3>{t("about.can_i_help_with_translations")}</h3>
+    <h3>
+      {t("about.can_i_help_with_translations", "Can I help with translations?")}
+    </h3>
     <p>
       <Trans i18nKey="about.confessit_is_translated">
         ConfessIt is translated into multiple languages. If you'd like to help
@@ -186,7 +209,7 @@ changeLanguage("en");
       </Trans>
     </p>
 
-    <h3>{t("about.can_i_help_write_code")}</h3>
+    <h3>{t("about.can_i_help_write_code", "Can I help write code?")}</h3>
     <p>
       <Trans i18nKey="about.we_welcome_new_contributions">
         We welcome new contributions. If you'd like to contribute to ConfessIt,
@@ -197,7 +220,7 @@ changeLanguage("en");
       </Trans>
     </p>
 
-    <h3>{t("about.about_the_developer")}</h3>
+    <h3>{t("about.about_the_developer", "About the Developer")}</h3>
     <p>
       <Trans i18nKey="about.mike_kasberg">
         <a href="https://www.mikekasberg.com">Mike Kasberg</a> develops ConfessIt
@@ -208,6 +231,13 @@ changeLanguage("en");
 
     <hr />
 
-    <p>{t("about.information")}</p>
+    <p>
+      {
+        t(
+          "about.information",
+          "Bible quotes in this app come from the Revised Standard Version of the Holy Bible, Second Catholic Edition. Information from the Catechism of the Catholic Church was also used.",
+        )
+      }
+    </p>
   </div>
 </Container>

--- a/src/pages/help.astro
+++ b/src/pages/help.astro
@@ -6,11 +6,11 @@ import { Trans } from "astro-i18next/components";
 changeLanguage("en");
 ---
 
-<Container title={t("navbar.help")}>
+<Container title={t("navbar.help", "Help")}>
   <div class="prose mx-auto">
-    <h1>{t("help.confessit_help")}</h1>
+    <h1>{t("help.confessit_help", "ConfessIt Help")}</h1>
 
-    <h2>{t("help.basic_usage")}</h2>
+    <h2>{t("help.basic_usage", "Basic Usage")}</h2>
 
     <ol>
       <li>
@@ -43,7 +43,7 @@ changeLanguage("en");
       </li>
     </ol>
 
-    <h2>{t("help.data_persistence")}</h2>
+    <h2>{t("help.data_persistence", "Data Persistence")}</h2>
 
     <p>
       <Trans i18nKey="help.data_persistence_text">

--- a/src/pages/prayers.astro
+++ b/src/pages/prayers.astro
@@ -6,44 +6,51 @@ import { Trans } from "astro-i18next/components";
 changeLanguage("en");
 ---
 
-<Container title={t("navbar.prayers")}>
+<Container title={t("navbar.prayers", "Prayers")}>
   <div class="prose lg:prose-lg mx-auto max-w-[48rem]">
-    <h1>{t("prayers.prayers")}</h1>
+    <h1>{t("prayers.prayers", "Prayers")}</h1>
 
     <ul>
       <li>
         <a href="#prayer-before-confession">
-          {t("prayers.prayer_before_confession")}
+          {t("prayers.prayer_before_confession", "Prayer Before Confession")}
         </a>
       </li>
       <li>
         <a href="#act-of-contrition">
-          {t("prayers.act_of_contrition")}
+          {t("prayers.act_of_contrition", "Act Of Contrition")}
         </a>
       </li>
       <li>
         <a href="#another-act-of-contrition">
-          {t("prayers.another_act_of_contrition")}
+          {t("prayers.another_act_of_contrition", "Another Act Of Contrition")}
         </a>
       </li>
       <li>
         <a href="#thanksgiving-after-confession">
-          {t("prayers.thanksgiving_after_confession")}
+          {
+            t(
+              "prayers.thanksgiving_after_confession",
+              "Thanksgiving After Confession",
+            )
+          }
         </a>
       </li>
       <li>
-        <a href="#our-father">{t("prayers.our_father")}</a>
+        <a href="#our-father">{t("prayers.our_father", "Our Father")}</a>
       </li>
       <li>
-        <a href="#hail-mary">{t("prayers.hail_mary")}</a>
+        <a href="#hail-mary">{t("prayers.hail_mary", "Hail Mary")}</a>
       </li>
       <li>
-        <a href="#hail-holy-queen">{t("prayers.hail_holy_queen")}</a>
+        <a href="#hail-holy-queen"
+          >{t("prayers.hail_holy_queen", "Hail Holy Queen")}</a
+        >
       </li>
     </ul>
 
     <h2 id="prayer-before-confession">
-      {t("prayers.prayer_before_confession")}
+      {t("prayers.prayer_before_confession", "Prayer Before Confession")}
     </h2>
     <p>
       <Trans i18nKey="prayers.prayer_before_confession_text">
@@ -64,7 +71,7 @@ changeLanguage("en");
     </p>
 
     <h2 id="act-of-contrition">
-      {t("prayers.act_of_contrition")}
+      {t("prayers.act_of_contrition", "Act Of Contrition")}
     </h2>
     <p>
       <Trans i18nKey="prayers.act_of_contrition_text">
@@ -83,7 +90,7 @@ changeLanguage("en");
     </p>
 
     <h2 id="another-act-of-contrition">
-      {t("prayers.another_act_of_contrition")}
+      {t("prayers.another_act_of_contrition", "Another Act Of Contrition")}
     </h2>
     <p>
       <Trans i18nKey="prayers.another_act_of_contrition_text">
@@ -103,7 +110,12 @@ changeLanguage("en");
     </p>
 
     <h2 id="thanksgiving-after-confession">
-      {t("prayers.thanksgiving_after_confession")}
+      {
+        t(
+          "prayers.thanksgiving_after_confession",
+          "Thanksgiving After Confession",
+        )
+      }
     </h2>
     <p>
       <Trans i18nKey="prayers.thanksgiving_after_confession_text">
@@ -127,7 +139,7 @@ changeLanguage("en");
     </p>
 
     <h2 id="our-father">
-      {t("prayers.our_father")}
+      {t("prayers.our_father", "Our Father")}
     </h2>
     <p>
       <Trans i18nKey="prayers.our_father_text">
@@ -148,7 +160,7 @@ changeLanguage("en");
     </p>
 
     <h2 id="hail-mary">
-      {t("prayers.hail_mary")}
+      {t("prayers.hail_mary", "Hail Mary")}
     </h2>
     <p>
       <Trans i18nKey="prayers.hail_mary_text">
@@ -167,7 +179,7 @@ changeLanguage("en");
     </p>
 
     <h2 id="hail-holy-queen">
-      {t("prayers.hail_holy_queen")}
+      {t("prayers.hail_holy_queen", "Hail Holy Queen")}
     </h2>
     <p>
       <Trans i18nKey="prayers.hail_holy_queen_text">


### PR DESCRIPTION
Fixes #101
also adds a DummyTranslation component, which though not used in the frontend, at least allows the i18next-scanner to pick up on the translation keys for commandments and faults: if you clean the locales folder and then run the scanner, the base English locale file will be recreated with all of the default values.