### PR TITLE
flag emojis vs textual representations of countries

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -62,7 +62,8 @@ const { title, bodyClass = "" } = Astro.props;
             <li>
               <LanguageSelector
                 showFlag={true}
-                class="select select-sm text-xs select-bordered mt-8 py-1 w-42"
+                class="select select-sm text-xs select-bordered mt-8 py-1 w-42 font-noto"
+                languageMapping={{ "pt-BR": "Português" }}
               />
             </li>
           </ul>
@@ -89,7 +90,7 @@ const { title, bodyClass = "" } = Astro.props;
         <div class="flex gap-4">
           <LanguageSelector
             showFlag={true}
-            class="hidden lg:inline-flex select select-bordered w-36"
+            class="hidden lg:inline-flex select select-bordered w-36 font-noto"
             languageMapping={{ "pt-BR": "Português" }}
           />
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+  font-family: "Noto Color Emoji";
+  unicode-range: U+1F1E6-1F1FF;
+  src: url(https://raw.githack.com/googlefonts/noto-emoji/main/fonts/NotoColorEmoji.ttf);
+}
+
 @layer base {
   html {
     font-family: "Iowan Old Style", "Palatino Linotype", "URW Palladio L", P052,

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -5,7 +5,11 @@ import typography from "@tailwindcss/typography";
 export default {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        noto: ["Noto Color Emoji", "sans-serif"],
+      },
+    },
   },
   plugins: [typography, daisyui],
   daisyui: {


### PR DESCRIPTION
Fixes #72
also completes the fix for the missing string "Portugues" https://github.com/kas-catholic/confessit-web/issues/88#issuecomment-2614116902, it was still missing for the "mobile" version of the LanguageSelector