### PR TITLE
Set trailingSlash to never

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import astroI18next from "astro-i18next";
 export default defineConfig({
   site: "https://confessit.app",
   output: "static",
+  trailingSlash: "never",
   integrations: [
     react(),
     AstroPWA({

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,9 @@
 
   # Default build command.
   command = "npx astro-i18next generate && npm run build"
+
+[[redirects]]
+  # Ensure we never have a trailing slash (it renders the wrong page)
+  from = "/*/"
+  to = "/:splat"
+  status = 301


### PR DESCRIPTION
I noticed that in production https://confessit.app/about-confession works correctly but https://confessit.app/about-confession/ serves the wrong page. We should be able to fix this by configuring Astro (and possibly Netlify) better.