### PR TITLE
Fix Pretty URLs Better

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,7 +8,10 @@ import astroI18next from "astro-i18next";
 export default defineConfig({
   site: "https://confessit.app",
   output: "static",
-  trailingSlash: "never",
+  trailingSlash: "always",
+  build: {
+    format: "directory",
+  },
   integrations: [
     react(),
     AstroPWA({

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,7 +16,7 @@
   command = "npx astro-i18next generate && npm run build"
 
 [[redirects]]
-  # Ensure we never have a trailing slash (it renders the wrong page)
-  from = "/*/"
-  to = "/:splat"
+  # Ensure we always have a trailing slash
+  from = "/*[^/]"
+  to = "/:splat/"
   status = 301

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,0 @@
-/about / 200
-/help / 200
-/prayers / 200
-/index.html / 301


### PR DESCRIPTION
We still have problems where our URLs are not working correctly. I think this will actually fix it.

- Remove some old `_redirects`. They were needed with a React SPA on Netlify, they are not needed with an Astro static site.
- Set `build.format` to directory. We _can't_ use `file` because Astro will generate links with .html but Netlify pretty URLs would not have the .html. So we get consistency with the directory option.
- Set `trailingSlash: "always"` to match the `build.format`.