### PR TITLE
Feat/77 - Add tracking for days since last confession

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@
   publish = "dist/"
 
   # Default build command.
-  command = "npx astro-i18next generate && npm run build"
+  command = "npm run i18n:generate && npm run build"
 
 [[redirects]]
   # Ensure we always have a trailing slash

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint": "npx eslint src",
-    "prepare": "husky"
+    "prepare": "husky",
+    "i18n:generate": "astro-i18next generate"
   },
   "eslintConfig": {
     "extends": "react-app",

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -436,6 +436,9 @@
     }
   },
   "sins_list": {
+    "clear_all_data": "Alle Daten löschen",
+    "finish_confession": "Beichte beenden",
+    "last_confession_on": "Deine letzte Beichte war am {{date}}.",
     "review": "Überprufen"
   },
   "walkthrough": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -120,6 +120,7 @@
     "step_3": "If you're unsure what to say in confession, swipe to the next tab, <strong>Walkthrough</strong>, to see roughly what you and the priest will say to each other in confession. You can review this during confession if you wish.",
     "step_4": "After you've gone to confession, use the <strong>Clear</strong> button to clear all the sins you've marked."
   },
+  "language": "en",
   "navbar": {
     "about": "About",
     "clear": "Clear",
@@ -436,6 +437,9 @@
     }
   },
   "sins_list": {
+    "clear_all_data": "Clear All Data",
+    "finish_confession": "Finish Confession",
+    "last_confession_on": "Your last confession was on {{date}}.",
     "review": "Review"
   },
   "walkthrough": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -389,6 +389,9 @@
     }
   },
   "sins_list": {
+    "clear_all_data": "Borrar todos los datos",
+    "finish_confession": "Terminar confesión",
+    "last_confession_on": "Tu última confesión fue el {{date}}.",
     "review": "Revise"
   },
   "walkthrough": {

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -386,6 +386,9 @@
     }
   },
   "sins_list": {
+    "clear_all_data": "Effacer toutes les données",
+    "finish_confession": "Terminer la confession",
+    "last_confession_on": "Ta dernière confession remonte au {{date}}.",
     "review": ""
   },
   "walkthrough": {

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -436,6 +436,9 @@
     }
   },
   "sins_list": {
+    "clear_all_data": "Cancella tutti i dati",
+    "finish_confession": "Concludi la confessione",
+    "last_confession_on": "La tua ultima confessione è stata il {{date}}.",
     "review": "Revisiona"
   },
   "walkthrough": {

--- a/public/locales/pt-BR/translation.json
+++ b/public/locales/pt-BR/translation.json
@@ -436,6 +436,9 @@
     }
   },
   "sins_list": {
+    "clear_all_data": "Apagar todos os dados",
+    "finish_confession": "Finalizar Confissão",
+    "last_confession_on": "Sua última confissão foi em {{date}}.",
     "review": "Revisar"
   },
   "walkthrough": {

--- a/src/components/ConfessIt.jsx
+++ b/src/components/ConfessIt.jsx
@@ -17,7 +17,7 @@ import WelcomeModal from "@components/WelcomeModal";
 const ConfessIt = () => {
   const [selectedSinIds, setSelectedSinIds] = useState([]);
   const [customSins, setCustomSins] = useState([]);
-
+  const [lastConfessionDate, setLastConfessionDate] = useState(null);
   // Load state from localStorage on component mount
   useEffect(() => {
     const storedState = localStorage.getItem("state");
@@ -26,6 +26,9 @@ const ConfessIt = () => {
       setSelectedSinIds(parsedState.selectedSinIds || []);
       setCustomSins(parsedState.customSins || []);
     }
+
+    const lastConfessionDateStr = localStorage.getItem("lastConfessionDate");
+    setLastConfessionDate(lastConfessionDateStr ?? null);
   }, []);
 
   // Persist state to localStorage whenever it changes
@@ -77,6 +80,23 @@ const ConfessIt = () => {
     return () => window.removeEventListener("clearButtonClicked", clearAll);
   }, []);
 
+  const handleFinishConfession = useCallback(() => {
+    const now = new Date();
+    const formattedDate = now.toISOString().slice(0, 10);
+
+    localStorage.setItem("lastConfessionDate", formattedDate);
+    setLastConfessionDate(formattedDate);
+    setSelectedSinIds([]);
+    setCustomSins([]);
+  }, [t]);
+
+  const handleClearAllData = useCallback(() => {
+    localStorage.clear();
+    setSelectedSinIds([]);
+    setCustomSins([]);
+    setLastConfessionDate(null);
+  }, []);
+
   return (
     <div className="w-full h-full">
       <Swiper
@@ -99,7 +119,13 @@ const ConfessIt = () => {
         </SwiperSlide>
         <SwiperSlide>
           <Column title={t("sins_list.review", "Review")}>
-            <SinsList sinsList={sinsList} onRemoveSinItem={removeSinItem} />
+            <SinsList
+              sinsList={sinsList}
+              onRemoveSinItem={removeSinItem}
+              onFinishConfession={handleFinishConfession}
+              onClearAllData={handleClearAllData}
+              lastConfessionDate={lastConfessionDate}
+            />
           </Column>
         </SwiperSlide>
         <SwiperSlide>

--- a/src/components/SinsList.jsx
+++ b/src/components/SinsList.jsx
@@ -1,6 +1,15 @@
 import SinListItem from "@components/SinListItem";
+import i18next from "i18next";
+import { useTranslation } from "react-i18next";
 
-const SinsList = ({ sinsList, onRemoveSinItem }) => {
+const SinsList = ({
+  sinsList,
+  onRemoveSinItem,
+  onFinishConfession,
+  onClearAllData,
+  lastConfessionDate,
+}) => {
+  const { t } = useTranslation();
   const sinItems = sinsList.map((sinItem, index) => (
     <SinListItem
       sinItem={sinItem}
@@ -9,7 +18,48 @@ const SinsList = ({ sinsList, onRemoveSinItem }) => {
     />
   ));
 
-  return <div className="flex flex-col px-4 gap-4">{sinItems}</div>;
+  const locale = i18next.language;
+  let formattedDate = null;
+  if (lastConfessionDate) {
+    const dateObj = new Date(lastConfessionDate);
+    formattedDate = dateObj.toLocaleDateString(locale, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }
+
+  return (
+    <div className="flex flex-col px-4 gap-4">
+      {lastConfessionDate && (
+        <div className="text-center text-base-content/80 mb-2">
+          {t("sins_list.last_confession_on", {
+            defaultValue: "Your last confession was on {{date}}.",
+            date: formattedDate,
+          })}
+        </div>
+      )}
+      {sinItems}
+      <div className="flex flex-col gap-2 mt-6 items-center">
+        {onFinishConfession && (
+          <button
+            className="btn btn-primary w-full max-w-xs"
+            onClick={onFinishConfession}
+          >
+            {t("sins_list.finish_confession", "Finish Confession")}
+          </button>
+        )}
+        {onClearAllData && (
+          <button
+            className="btn btn-outline w-full max-w-xs"
+            onClick={onClearAllData}
+          >
+            {t("sins_list.clear_all_data", "Clear All Data")}
+          </button>
+        )}
+      </div>
+    </div>
+  );
 };
 
 export default SinsList;


### PR DESCRIPTION
This PR adds a simple but useful feature: when the user finishes a confession by clicking the "Finish Confession" button, the app saves the current date as the last confession date. Then, it shows the user exactly when the last confession happened (e.g., "Your last confession was on July 5, 2025.").

This way, users can keep better track of their confession history right on the main screen.
I also kept the "Clear All Data" button working separately, so users can reset everything if needed.

Issue [#77](https://github.com/kas-catholic/confessit-web/issues/77)

Thanks for the opportunity to contribute!