### PR TITLE
Fix Mobile Drag'n'Drop

### DIFF
--- a/src/components/ConfessIt.jsx
+++ b/src/components/ConfessIt.jsx
@@ -121,6 +121,7 @@ const ConfessIt = () => {
         slidesPerView={1}
         breakpoints={{ 1024: { slidesPerView: 3, spaceBetween: 0 } }}
         pagination={{ clickable: true }}
+        noSwiping={true}
         className="h-full"
       >
         <SwiperSlide className="h-full">

--- a/src/components/SinListItem.jsx
+++ b/src/components/SinListItem.jsx
@@ -2,7 +2,11 @@ import { TrashIcon } from "@heroicons/react/16/solid";
 import { useSortable } from "@dnd-kit/react/sortable";
 
 const GripIcon = () => (
-  <svg viewBox="0 0 12 12" fill="currentColor" className="w-4 h-4">
+  <svg
+    viewBox="0 0 12 12"
+    fill="currentColor"
+    className="w-6 h-6 md:w-4 md:h-4"
+  >
     <circle cx="2" cy="2" r="1.2" />
     <circle cx="6" cy="2" r="1.2" />
     <circle cx="2" cy="6" r="1.2" />
@@ -28,7 +32,7 @@ const SinListItem = ({ sinItem, onRemoveSinItem, id, index }) => {
     >
       <div
         ref={handleRef}
-        className="cursor-grab active:cursor-grabbing text-base-content/40 hover:text-base-content/70 shrink-0 p-1"
+        className="cursor-grab active:cursor-grabbing text-base-content/40 hover:text-base-content/70 shrink-0 p-2 md:p-1 touch-none select-none swiper-no-swiping"
         aria-label="Drag to reorder"
       >
         <GripIcon />


### PR DESCRIPTION
Dragn'n'Drop was not working on mobile.

- Text selection on long-press — Added select-none to prevent the browser from highlighting text when touching the drag handle.
- Browser scroll intercepting drag start — Added touch-none so the browser doesn't treat the touch as a scroll gesture, allowing @dnd-kit to capture it.
- SwiperJS hijacking touch events — Added swiper-no-swiping to the handle and enabled noSwiping={true} on the <Swiper> so slide navigation doesn't block the drag.
- Tiny touch target on mobile — Increased the grip icon to w-6 h-6 on mobile and used responsive padding (p-2 md:p-1) for a ~40×40px thumb-friendly target while keeping it compact on desktop.